### PR TITLE
Make request ID extractable in request handlers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ pub struct TracingLoggerMiddleware<S> {
     service: S,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct RequestId(Uuid);
 
 impl std::ops::Deref for RequestId {
@@ -188,11 +188,6 @@ impl FromRequest for RequestId {
     type Config = ();
 
     fn from_request(req: &HttpRequest, _: &mut Payload) -> Self::Future {
-        ready(
-            req.extensions()
-                .get::<RequestId>()
-                .map(RequestId::clone)
-                .ok_or(()),
-        )
+        ready(req.extensions().get::<RequestId>().copied().ok_or(()))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,9 +115,23 @@ pub struct TracingLoggerMiddleware<S> {
 #[derive(Clone)]
 pub struct RequestId(Uuid);
 
-impl RequestId {
-    pub fn uuid(&self) -> &Uuid {
+impl std::ops::Deref for RequestId {
+    type Target = Uuid;
+
+    fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl std::convert::Into<Uuid> for RequestId {
+    fn into(self) -> Uuid {
+        self.0
+    }
+}
+
+impl std::fmt::Display for RequestId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,8 @@ pub struct TracingLoggerMiddleware<S> {
     service: S,
 }
 
-/// A unique identifier for each incomming request. This ID is added to the logger span.
+/// A unique identifier for each incomming request. This ID is added to the logger span, even if
+/// the `RequestId` is never extracted.
 ///
 /// Extracting a `RequestId` when the `TracingLogger` middleware is not registered, will result in
 /// a internal server error.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,28 @@ pub struct TracingLoggerMiddleware<S> {
     service: S,
 }
 
+/// A unique identifier for each incomming request. This ID is added to the logger span.
+///
+/// Extracting a `RequestId` when the `TracingLogger` middleware is not registered, will result in
+/// a internal server error.
+///
+/// # Usage
+/// ```rust
+/// use actix_web::get;
+/// use tracing_actix_web::RequestId;
+/// use uuid::Uuid;
+///
+/// #[get("/")]
+/// async fn index(request_id: RequestId) -> String {
+///   format!("{}", request_id)
+/// }
+///
+/// #[get("/2")]
+/// async fn index2(request_id: RequestId) -> String {
+///  let uuid: Uuid = request_id.into();
+///   format!("{}", uuid)
+/// }
+/// ```
 #[derive(Clone, Copy)]
 pub struct RequestId(Uuid);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,6 @@ where
             .map(|h| h.to_str().unwrap_or(""))
             .unwrap_or("");
         let request_id = RequestId(Uuid::new_v4());
-        req.extensions_mut().insert(request_id.clone());
         let span = tracing::info_span!(
             "Request",
             request_path = %req.path(),
@@ -152,6 +151,7 @@ where
             request_id = %request_id.0,
             status_code = tracing::field::Empty,
         );
+        req.extensions_mut().insert(request_id);
         let fut = self.service.call(req);
         Box::pin(
             async move {


### PR DESCRIPTION
Concept to allow extracting the request ID, that is used in the logs and use it in request handlers.

With this you should be able to do something like this:

```rust
#[get("/")]
fn index(request_id: RequestId) -> String {
  format!("{}", request_id.uuid())
}
```

Some things, I'm not quite happy about, that should be discussed:

- [x] RequestId is cloned, when it is extracted from the request. This could be solved by using [`Extensions::remove`](https://docs.rs/actix-web/3.2.0/actix_web/dev/struct.Extensions.html#method.remove) instead of [`Extensions::get`](https://docs.rs/actix-web/3.2.0/actix_web/dev/struct.Extensions.html#method.get) but I'm not quite sure, what the consequences of removing the `RequestId` are...
- [x] `pub fn uuid(&self) -> &Uuid` exposes implementation details (`Uuid` is used). Maybe simply `impl Display for RequestId`?
- [x] No dedicated error type if `RequestId` cannot be extracted

Closes #2