### PR TITLE
Add HTTP method to span fields

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,6 +180,7 @@ where
         let request_id = RequestId(Uuid::new_v4());
         let span = tracing::info_span!(
             "Request",
+            http.method = %req.method(),
             request_path = %req.path(),
             user_agent = %user_agent,
             client_ip_address = %req.connection_info().realip_remote_addr().unwrap_or(""),


### PR DESCRIPTION
Closes #5.

Nothing complex here, just adding the method to the span. (: 
As a bonus, the method is marked as required by [OTEL conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md), so it's even greater to have it here.