### PR TITLE
Don't pull in unneeded dependency on futures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ emit_event_on_error = []
 actix-web = { version = "=4.0.0-beta.9", default-features = false }
 tracing = "0.1.19"
 tracing-futures = "0.2.4"
-futures = "0.3.5"
 uuid = { version = "0.8.1", features = ["v4"] }
 opentelemetry_0_13_pkg = { package = "opentelemetry", version = "0.13", optional = true }
 opentelemetry_0_14_pkg = { package = "opentelemetry", version = "0.14", optional = true }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,8 +1,7 @@
 use crate::{DefaultRootSpanBuilder, RequestId, RootSpan, RootSpanBuilder};
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform};
 use actix_web::{Error, HttpMessage, ResponseError};
-use futures::future::{ok, Ready};
-use std::future::Future;
+use std::future::{ready, Future, Ready};
 use std::pin::Pin;
 use tracing::Span;
 use tracing_futures::Instrument;
@@ -100,10 +99,10 @@ where
     type Future = Ready<Result<Self::Transform, Self::InitError>>;
 
     fn new_transform(&self, service: S) -> Self::Future {
-        ok(TracingLoggerMiddleware {
+        ready(Ok(TracingLoggerMiddleware {
             service,
             root_span_builder: std::marker::PhantomData::default(),
-        })
+        }))
     }
 }
 


### PR DESCRIPTION
I added this to my project while reading through Zero to Production in Rust and found it pulled in a few `futures` crates that I had so far managed to avoid pulling in. Since the standard library has the `Ready` type now, which was the only thing imported from futures, I've just removed the dependency entirely rather than swapping the dependency to `futures-util` instead. This is fine since the actix-web 4.0.0-beta.9 bumped MSRV to 1.51, and Ready was added in 1.48.