### PR TITLE
Allow root_span to wrap the full middlware chain, not just the output future

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -133,7 +133,7 @@ where
         let root_span_wrapper = RootSpan::new(root_span.clone());
         req.extensions_mut().insert(root_span_wrapper);
 
-        let fut = self.service.call(req);
+        let fut = root_span.in_scope(|| self.service.call(req));
         Box::pin(
             async move {
                 let outcome = fut.await;


### PR DESCRIPTION
I noticed that some logging in one of my middlwares wasn't getting wrapped in the root span, and I determined it was because the function call that produces the middleware future is not itself wrapped in the root span