### PR TITLE
Hold root span across polls in streamed body

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ emit_event_on_error = []
 
 [dependencies]
 actix-web = { version = "=4.0.0-beta.9", default-features = false }
+pin-project = "1.0.0"
 tracing = "0.1.19"
 tracing-futures = "0.2.4"
 uuid = { version = "0.8.1", features = ["v4"] }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -19,7 +19,6 @@ use tracing::Span;
 /// In this example we add a [`tracing::Subscriber`] to output structured logs to the console.
 ///
 /// ```rust
-/// use actix_web::middleware::Logger;
 /// use actix_web::App;
 /// use tracing::{Subscriber, subscriber::set_global_default};
 /// use tracing_actix_web::TracingLogger;
@@ -60,8 +59,26 @@ use tracing::Span;
 /// }
 /// ```
 ///
+/// Like [`actix-web`]'s [`Logger`], in order to use `TracingLogger` inside a Scope, Resource, or
+/// Condition, the [`Compat`] middleware must be used.
+///
+/// ```rust
+/// use actix_web::middleware::Compat;
+/// use actix_web::{web, App};
+/// use tracing_actix_web::TracingLogger;
+///
+/// fn main() {
+///     let app = App::new()
+///         .service(
+///             web::scope("/some/route")
+///                 .wrap(Compat::new(TracingLogger::default())),
+///         );
+/// }
+/// ```
+///
 /// [`actix-web`]: https://docs.rs/actix-web
-/// [`Logger`]: https://docs.rs/actix-web/3.0.2/actix_web/middleware/struct.Logger.html
+/// [`Logger`]: https://docs.rs/actix-web/4.0.0-beta.9/actix_web/middleware/struct.Logger.html
+/// [`Compat`]: https://docs.rs/actix-web/4.0.0-beta.9/actix_web/middleware/struct.Compat.html
 /// [`tracing`]: https://docs.rs/tracing
 pub struct TracingLogger<RootSpan: RootSpanBuilder> {
     root_span_builder: std::marker::PhantomData<RootSpan>,

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -182,7 +182,7 @@ pub struct StreamSpan<B> {
 impl<F, B, RootSpanType> Future for TracingResponse<F, RootSpanType>
 where
     F: Future<Output = Result<ServiceResponse<B>, Error>>,
-    B: actix_web::dev::MessageBody + 'static,
+    B: MessageBody + 'static,
     RootSpanType: RootSpanBuilder,
 {
     type Output = Result<ServiceResponse<StreamSpan<B>>, Error>;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -177,7 +177,7 @@ where
         let span = this.span;
 
         span.in_scope(|| match fut.poll(cx) {
-            Poll::Pending => return Poll::Pending,
+            Poll::Pending => Poll::Pending,
             Poll::Ready(outcome) => {
                 RootSpanType::on_request_end(Span::current(), &outcome);
 

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -67,13 +67,11 @@ use tracing::Span;
 /// use actix_web::{web, App};
 /// use tracing_actix_web::TracingLogger;
 ///
-/// fn main() {
-///     let app = App::new()
-///         .service(
-///             web::scope("/some/route")
-///                 .wrap(Compat::new(TracingLogger::default())),
-///         );
-/// }
+/// let app = App::new()
+///     .service(
+///         web::scope("/some/route")
+///             .wrap(Compat::new(TracingLogger::default())),
+///     );
 /// ```
 ///
 /// [`actix-web`]: https://docs.rs/actix-web

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -92,7 +92,7 @@ where
     S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
     S::Future: 'static,
     B: MessageBody + 'static,
-    RootSpan: RootSpanBuilder + Unpin,
+    RootSpan: RootSpanBuilder,
 {
     type Response = ServiceResponse<StreamSpan<B>>;
     type Error = Error;
@@ -120,7 +120,7 @@ where
     S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
     S::Future: 'static,
     B: MessageBody + 'static,
-    RootSpanType: RootSpanBuilder + Unpin,
+    RootSpanType: RootSpanBuilder,
 {
     type Response = ServiceResponse<StreamSpan<B>>;
     type Error = Error;
@@ -166,7 +166,7 @@ impl<F, B, RootSpanType> Future for TracingResponse<F, RootSpanType>
 where
     F: Future<Output = Result<ServiceResponse<B>, Error>>,
     B: actix_web::dev::MessageBody + 'static,
-    RootSpanType: RootSpanBuilder + Unpin,
+    RootSpanType: RootSpanBuilder,
 {
     type Output = Result<ServiceResponse<StreamSpan<B>>, Error>;
 


### PR DESCRIPTION
This introduces a new `TracingResponse` Future and a new `StreamSpan` MessageBody. Now, each poll of the message body happens inside the root span, meaning that default and custom body streams will be properly wrapped. Since the span is held in the body, it will remain open until the body itself is dropped.

This also adds a new dependency on `pin_project` which introduces unsafe code via it's `pin_project` macro. The alternative would be to `Box::pin` the body and the inner service's future, which may be preferable. 

closes https://github.com/LukeMathWalker/tracing-actix-web/issues/39

Just a note that if any consumers of this crate were relying on timings provided previously, this will make all requests that produce a body seem to take longer, since the span is held open longer