### PR TITLE
Obtain status code from response errors using error_response() instead of status_code()

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -249,7 +249,7 @@ fn emit_event_on_error<B: 'static>(outcome: &Result<ServiceResponse<B>, actix_we
 }
 
 fn emit_error_event(response_error: &dyn ResponseError) {
-    let status_code = response_error.status_code();
+    let status_code = response_error.error_response().status();
     let error_msg_prefix = "Error encountered while processing the incoming HTTP request";
     if status_code.is_client_error() {
         tracing::warn!("{}: {:?}", error_msg_prefix, response_error);


### PR DESCRIPTION
Documentation for `ResponseError::status_code()` states that "A 500 Internal Server Error is used by default. If error_response is also implemented and does not call self.status_code(), then this will not be used." [actix-web docs](https://docs.rs/actix-web/4.0.0-beta.9/actix_web/trait.ResponseError.html#method.status_code)

I believe that this implies that if status_code() is implemented, it should only be used as a helper method called by error_response(). Therefore, error_response() should be treated as the source-of-truth for the status code of the error response.

This would also make the zero2prod book's code interface more easily with OTEL collectors 😀

This PR passes `cargo test`, `cargo fmt`, and `cargo clippy`.