### PR TITLE
Use http response for determining status code on errors

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -239,6 +239,7 @@ fn emit_event_on_error<B: 'static>(outcome: &Result<ServiceResponse<B>, actix_we
     match outcome {
         Ok(response) => {
             if let Some(err) = response.response().error() {
+                // use the status code already constructed for the outgoing HTTP response
                 emit_error_event(err.as_response_error(), response.status())
             }
         }


### PR DESCRIPTION
This PR addresses my concern with #45 while not making any performance sacrifices. 

When using the `ResponseError` trait, by the time that the middleware receives the HTTP response (named `outcome` with type `Result<ServiceResponse<B>, actix_web::Error>`), Actix has already constructed an `HttpResponse` for us, even on errors. (When using the `ResponseError` pattern, we don't expect code to follow the `Err(Actix_web::Error)` code-path.) This means that the (correct) HTTP status code can be easily obtained by just running `response.status()`, which is a zero-cost reference to a value already existing in memory. 

The benefit of this approach is that it does not require users of the package to implement `ResponseError::status_code()`, which in Actix's documentation is implied to be merely used as a helper function by `ResponseError::error_response()` (see #45 for a more in-depth explanation).

PR has been tested using `cargo fmt`, `cargo test`, `cargo clippy`, and using my zero2prod fork which was able to successfully report the correct HTTP status codes to Honeycomb without implementing `status_code()`. 

EDIT: the status code reference is not a zero-cost reference, as there is one reference to a boxed value to access it. The alternative, though, is recomputing the status code.