### PR TITLE
Fixed opentelemetry feature breaking due to root_span! use

### DIFF
--- a/src/root_span_macro.rs
+++ b/src/root_span_macro.rs
@@ -97,12 +97,11 @@ macro_rules! root_span {
             );
             std::mem::drop(connection_info);
 
-            #[cfg(any(
-                feature = "opentelemetry_0_13",
-                feature = "opentelemetry_0_14",
-                feature = "opentelemetry_0_15",
-                feature = "opentelemetry_0_16"
-            ))]
+            // Previously, this line was instrumented with an opentelemetry-specific feature
+            // flag check. However, this resulted in the feature flags being resolved in the crate
+            // which called `root_span!` as opposed to being resolved by this crate as expected.
+            // Therefore, this function simply wraps an internal function with the feature flags
+            // to ensure that the flags are resolved against this crate.
             $crate::root_span_macro::private::set_otel_parent(&$request, &span);
 
             span
@@ -123,14 +122,14 @@ pub mod private {
 
     pub use tracing;
 
-    #[cfg(any(
-        feature = "opentelemetry_0_13",
-        feature = "opentelemetry_0_14",
-        feature = "opentelemetry_0_15",
-        feature = "opentelemetry_0_16"
-    ))]
     #[doc(hidden)]
     pub fn set_otel_parent(req: &ServiceRequest, span: &tracing::Span) {
+        #[cfg(any(
+            feature = "opentelemetry_0_13",
+            feature = "opentelemetry_0_14",
+            feature = "opentelemetry_0_15",
+            feature = "opentelemetry_0_16"
+        ))]
         crate::otel::set_otel_parent(req, span);
     }
 


### PR DESCRIPTION
Fixes https://github.com/LukeMathWalker/tracing-actix-web/issues/50

The `root_span!` macro included some feature flag checks. However, the
`root_span!` macro might end up being used in other crates consuming
`tracing-actix-web`, and those feature flag checks would be copied in
verbatim. The result is that the feature flag checks for things like
`opentelemetry_0_14` would actually check the consuming crates flags
rather than the flags for `tracing-actix-web`.

This commit moves those feature flag checks out of the macro, so they
are always resolved against `tracing-actix-web`.