### PR TITLE
add relay feature basics and example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "examples/opentelemetry", "examples/custom-root-span"]
+members = [".", "examples/opentelemetry", "examples/custom-root-span", "./examples/relay"]
 
 [package]
 name = "tracing-actix-web"
@@ -25,9 +25,13 @@ opentelemetry_0_14 = ["opentelemetry_0_14_pkg", "tracing-opentelemetry_0_13_pkg"
 opentelemetry_0_15 = ["opentelemetry_0_15_pkg", "tracing-opentelemetry_0_14_pkg"]
 opentelemetry_0_16 = ["opentelemetry_0_16_pkg", "tracing-opentelemetry_0_16_pkg"]
 emit_event_on_error = []
+relay = ["futures", "http", "hyper", "tokio", "tonic"]
 
 [dependencies]
 actix-web = { version = "=4.0.0-beta.11", default-features = false }
+futures = { version = "0.3", default-features = false, features = ["alloc"], optional = true }
+http = { version = "0.2.5", optional = true }
+hyper = { version = "0.14", optional = true }
 pin-project = "1.0.0"
 tracing = "0.1.19"
 tracing-futures = "0.2.4"
@@ -36,6 +40,8 @@ opentelemetry_0_13_pkg = { package = "opentelemetry", version = "0.13", optional
 opentelemetry_0_14_pkg = { package = "opentelemetry", version = "0.14", optional = true }
 opentelemetry_0_15_pkg = { package = "opentelemetry", version = "0.15", optional = true }
 opentelemetry_0_16_pkg = { package = "opentelemetry", version = "0.16", optional = true }
+tokio = { version = "1.14.0", features = ["rt"], optional = true }
+tonic = { version = "0.5.2", optional = true }
 tracing-opentelemetry_0_12_pkg = { package = "tracing-opentelemetry",version = "0.12", optional = true }
 tracing-opentelemetry_0_13_pkg = { package = "tracing-opentelemetry", version = "0.13", optional = true }
 tracing-opentelemetry_0_14_pkg = { package = "tracing-opentelemetry",version = "0.14", optional = true }

--- a/examples/relay/Cargo.toml
+++ b/examples/relay/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "relay"
+version = "0.1.0"
+authors = ["Romain Kelifa <romain.kelifa@gmail.com>"]
+edition = "2018"
+
+license = "MIT/Apache-2.0"
+
+[[bin]]
+name = "facade"
+path = "src/facade.rs"
+
+[[bin]]
+name = "microservice"
+path = "src/microservice.rs"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+actix-web = "=4.0.0-beta.11"
+anyhow = "1"
+prost = "0.8.0"
+serde = { version = "1", features = ["derive"] }
+tokio = { version = "1", features = ["full"] }
+tonic = "0.5.2"
+tracing = "0.1.19"
+tracing-actix-web = { path = "../..", features = ["relay"] }
+tracing-log = "0.1.2"
+tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
+
+[build-dependencies]
+tonic-build = "0.5.2"

--- a/examples/relay/README.md
+++ b/examples/relay/README.md
@@ -1,0 +1,51 @@
+# relay across microservices
+
+By enabling feature `relay`, you can relay `request_id` across request calls and receptions, allowing you to track a request across multiple services.
+
+## Running
+
+In the terminal, open 3 separate tabs, and then run the following commands:
+
+1. Run the `microservice` first:
+    ```sh
+    cargo --package relay --bin microservice
+    ```
+
+2. Then run the `facade`:
+    ```sh
+    cargo --package relay --bin facade
+    ```
+
+3. Query the service, e.g.:
+    Fetch all users:
+    ```sh
+    curl http://127.0.0.1:8080/users
+    ```
+    Fetch only male users:
+    ```sh
+    curl http://127.0.0.1:8080/users\?gender\=male
+    ```
+    Fetch only female users:
+    ```sh
+    curl http://127.0.0.1:8080/users\?gender\=female
+    ```
+
+Check the `request_id` in the console logs,
+you'll notice that it's piped from the `facade` down to the `microservice` !
+
+---
+
+Please note that if you call the `microservice` directly, e.g. with [ghz](https://ghz.sh/):
+
+```sh
+ghz \
+  --insecure \
+  --async \
+  -n 1 \
+  --import-paths ./examples/relay/proto \
+  --proto ./service.proto \
+  --call users.Protocol.Fetch \
+  127.0.0.1:50051
+```
+
+A `request_id` will still be generated for you, being consistent with `tracing-actix-web` middleware.

--- a/examples/relay/build.rs
+++ b/examples/relay/build.rs
@@ -1,0 +1,8 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::configure()
+        .build_client(true)
+        .build_server(true)
+        .protoc_arg("--experimental_allow_proto3_optional")
+        .compile(&["service.proto"], &["proto"])?;
+    Ok(())
+}

--- a/examples/relay/proto/service.proto
+++ b/examples/relay/proto/service.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+package users;
+
+enum Gender {
+  FEMALE = 0;
+  MALE = 1;
+}
+
+message Filter {
+  optional Gender gender = 1;
+}
+
+message Users {
+  repeated User users = 1;
+}
+
+message User {
+  string name = 1;
+  Gender gender = 2;
+}
+
+service Protocol {
+  rpc Fetch(Filter) returns (Users) {};
+}

--- a/examples/relay/src/domain.rs
+++ b/examples/relay/src/domain.rs
@@ -1,0 +1,62 @@
+use actix_web::web::Query;
+
+#[derive(Debug, Clone)]
+pub enum ConversionError {
+    Invalid(String),
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Gender {
+    Female,
+    Male,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct User {
+    pub name: String,
+    pub gender: Gender,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct Filter {
+    pub gender: Option<Gender>,
+}
+
+impl From<Option<Query<Filter>>> for super::protocol::users::Filter {
+    fn from(input: Option<Query<Filter>>) -> Self {
+        Self {
+            gender: input.and_then(|query| query.into_inner().gender).and_then(
+                |gender| match gender {
+                    Gender::Female => Some(super::protocol::users::Gender::Female as i32),
+                    Gender::Male => Some(super::protocol::users::Gender::Male as i32),
+                },
+            ),
+        }
+    }
+}
+
+impl std::convert::TryFrom<super::protocol::users::Users> for Vec<User> {
+    type Error = ConversionError;
+
+    fn try_from(input: super::protocol::users::Users) -> Result<Self, Self::Error> {
+        let mut users = Vec::<User>::with_capacity(input.users.len());
+        for user in input.users {
+            let gender = match user.gender {
+                female if female == super::protocol::users::Gender::Female as i32 => Gender::Female,
+                male if male == super::protocol::users::Gender::Male as i32 => Gender::Male,
+                unknown => {
+                    return Err(ConversionError::Invalid(format!(
+                        "unknown gender ({})",
+                        unknown
+                    )))
+                }
+            };
+            users.push(User {
+                name: user.name,
+                gender,
+            })
+        }
+        Ok(users)
+    }
+}

--- a/examples/relay/src/facade.rs
+++ b/examples/relay/src/facade.rs
@@ -1,0 +1,69 @@
+pub mod domain;
+pub mod init;
+pub mod protocol;
+use protocol::users::protocol_client::ProtocolClient;
+
+use actix_web::{
+    get,
+    http::Uri,
+    web::{self, Query},
+    App, HttpResponse, HttpServer, Responder,
+};
+use init::once;
+use std::net::SocketAddr;
+use tonic::{codegen::InterceptedService, transport::Channel};
+use tracing_actix_web::{Relay, RelayInterceptor, TracingLogger};
+
+pub type GrpcClient = ProtocolClient<InterceptedService<Channel, RelayInterceptor>>;
+
+struct State {
+    client: GrpcClient,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    once::init();
+    let address: SocketAddr = "127.0.0.1:8080".parse()?;
+    let uri: Uri = "http://127.0.0.1:50051".parse()?;
+    let channel = Channel::builder(uri).connect().await?;
+    let client: GrpcClient = ProtocolClient::with_interceptor(channel, RelayInterceptor);
+    HttpServer::new(move || {
+        App::new()
+            .wrap(Relay)
+            .wrap(TracingLogger::default())
+            .app_data(web::Data::new(State {
+                client: client.clone(),
+            }))
+            .configure(|config| {
+                config.service(fetch);
+            })
+    })
+    .bind(address)?
+    .run()
+    .await?;
+    Ok(())
+}
+
+#[tracing::instrument(name = "Fetch users", skip(state), fields(protocol = "rest"))]
+#[get("/users")]
+async fn fetch(state: web::Data<State>, filter: Option<Query<domain::Filter>>) -> impl Responder {
+    use std::convert::TryFrom;
+    let mut client: GrpcClient = state.client.clone();
+    match client.fetch(protocol::users::Filter::from(filter)).await {
+        Ok(response) => match Vec::<domain::User>::try_from(response.into_inner()) {
+            Ok(users) => HttpResponse::Ok().json(users),
+            Err(e) => {
+                tracing::event!(
+                    tracing::Level::ERROR,
+                    "Failed to convert users from protobuf message: {:?}",
+                    e
+                );
+                HttpResponse::InternalServerError().finish()
+            }
+        },
+        Err(e) => {
+            tracing::event!(tracing::Level::ERROR, "Failed to fetch users: {:?}", e);
+            HttpResponse::InternalServerError().finish()
+        }
+    }
+}

--- a/examples/relay/src/init.rs
+++ b/examples/relay/src/init.rs
@@ -1,0 +1,23 @@
+pub mod once {
+    use std::sync::Once;
+
+    use tracing::{subscriber::set_global_default, Subscriber};
+    use tracing_log::LogTracer;
+    use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Registry};
+
+    static INIT: Once = Once::new();
+
+    fn get_subscriber() -> impl Subscriber + Send + Sync {
+        let env_filter = EnvFilter::new("trace");
+        let stdout_layer = tracing_subscriber::fmt::layer().pretty();
+        Registry::default().with(env_filter).with(stdout_layer)
+    }
+
+    pub fn init() {
+        INIT.call_once(|| {
+            let subscriber = get_subscriber();
+            LogTracer::init().expect("Failed to initialize logger");
+            set_global_default(subscriber).expect("Failed to set subscriber");
+        });
+    }
+}

--- a/examples/relay/src/microservice.rs
+++ b/examples/relay/src/microservice.rs
@@ -1,0 +1,61 @@
+pub mod domain;
+pub mod init;
+pub mod protocol;
+use std::net::SocketAddr;
+
+use protocol::users::protocol_server::Protocol;
+use protocol::users::protocol_server::ProtocolServer;
+
+use init::once;
+use tonic::{transport::Server, Response, Status};
+use tracing_actix_web::RelayService;
+
+#[derive(Default)]
+pub struct Service;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    once::init();
+    let address: SocketAddr = "127.0.0.1:50051".parse()?;
+    let service = Service::default();
+    Server::builder()
+        .add_service(RelayService::new(ProtocolServer::new(service)))
+        .serve(address)
+        .await?;
+    Ok(())
+}
+
+#[tonic::async_trait]
+impl Protocol for Service {
+    #[tracing::instrument(name = "Fetch users", skip(self), fields(protocol = "grpc"))]
+    async fn fetch(
+        &self,
+        request: tonic::Request<protocol::users::Filter>,
+    ) -> Result<Response<protocol::users::Users>, Status> {
+        let database = vec![
+            protocol::users::User {
+                name: "John".to_string(),
+                gender: protocol::users::Gender::Male as i32,
+            },
+            protocol::users::User {
+                name: "Bob".to_string(),
+                gender: protocol::users::Gender::Male as i32,
+            },
+            protocol::users::User {
+                name: "Alice".to_string(),
+                gender: protocol::users::Gender::Female as i32,
+            },
+        ];
+        let filter = request.into_inner();
+        let users = database
+            .into_iter()
+            .filter(|user| {
+                filter
+                    .gender
+                    .map(|gender| user.gender == gender)
+                    .unwrap_or(true)
+            })
+            .collect();
+        Ok(tonic::Response::new(protocol::users::Users { users }))
+    }
+}

--- a/examples/relay/src/protocol.rs
+++ b/examples/relay/src/protocol.rs
@@ -1,0 +1,3 @@
+pub mod users {
+    tonic::include_proto!("users");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,6 +241,11 @@ pub use root_span_builder::{DefaultRootSpanBuilder, RootSpanBuilder};
 #[doc(hidden)]
 pub mod root_span_macro;
 
+#[cfg(feature = "relay")]
+mod relay;
+#[cfg(feature = "relay")]
+pub use relay::{interceptor::RelayInterceptor, middleware::Relay, service::RelayService};
+
 #[cfg(any(
     feature = "opentelemetry_0_13",
     feature = "opentelemetry_0_14",

--- a/src/relay/interceptor.rs
+++ b/src/relay/interceptor.rs
@@ -1,0 +1,25 @@
+use tonic::service::Interceptor;
+
+/// Use with tonic grpc client in actix server context,
+/// so that your grpc client automatically pipe the request id to its metadata.
+///
+/// Here the interceptor doesn't have access to the initial parent request,
+/// so it uses a task local to store the request id.
+#[derive(Debug, Clone)]
+pub struct RelayInterceptor;
+impl Interceptor for RelayInterceptor {
+    fn call(&mut self, request: tonic::Request<()>) -> Result<tonic::Request<()>, tonic::Status> {
+        // safety: must always be set prior first read
+        let request_id = super::REQUEST_ID.get();
+        let mut request = request;
+        request.metadata_mut().insert(
+            "request_id",
+            request_id
+                .to_hyphenated_ref()
+                .to_string()
+                .parse()
+                .expect("Convert request_id to ASCII metadata"),
+        );
+        Ok(request)
+    }
+}

--- a/src/relay/middleware.rs
+++ b/src/relay/middleware.rs
@@ -1,0 +1,57 @@
+use std::{future::Future, pin::Pin};
+
+use crate::RequestId;
+use actix_web::{
+    body::MessageBody,
+    dev::{Service, ServiceRequest, ServiceResponse, Transform},
+    Error, HttpMessage,
+};
+
+/// Use in server actix context,
+/// to expose the request id to the [`RelayInterceptor`].
+///
+/// This middleware is meant to be used in conjunction with [`TracingLogger`] middleware.
+#[derive(Clone)]
+pub struct Relay;
+
+pub struct RelayMiddleware<S> {
+    service: S,
+}
+impl<S, B> Transform<S, ServiceRequest> for Relay
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = actix_web::Error>,
+    S::Future: 'static,
+    B: MessageBody + 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = actix_web::Error;
+    type Transform = RelayMiddleware<S>;
+    type InitError = ();
+    type Future = std::future::Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        std::future::ready(Ok(RelayMiddleware { service }))
+    }
+}
+impl<S, B> Service<ServiceRequest> for RelayMiddleware<S>
+where
+    S: Service<ServiceRequest, Response = ServiceResponse<B>, Error = Error>,
+    S::Future: 'static,
+    B: MessageBody + 'static,
+{
+    type Response = ServiceResponse<B>;
+    type Error = actix_web::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>>>>;
+
+    actix_web::dev::forward_ready!(service);
+
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        let request_id = req.extensions().get::<RequestId>().cloned().unwrap();
+        let future =
+            super::REQUEST_ID.sync_scope(request_id.clone(), move || self.service.call(req));
+        Box::pin(super::REQUEST_ID.scope(request_id, async move {
+            let response: Result<Self::Response, Self::Error> = future.await;
+            response
+        }))
+    }
+}

--- a/src/relay/mod.rs
+++ b/src/relay/mod.rs
@@ -1,0 +1,14 @@
+//! feature relay
+//!
+//! Provide convenience types
+//! to automatically pipe [`RequestId`] across gRPC calls
+
+pub mod interceptor;
+pub mod middleware;
+pub mod service;
+
+use crate::RequestId;
+
+tokio::task_local! {
+  static REQUEST_ID: RequestId;
+}

--- a/src/relay/service.rs
+++ b/src/relay/service.rs
@@ -1,0 +1,88 @@
+use futures::future::BoxFuture;
+use hyper::{Request, Response};
+use std::convert::TryFrom;
+use std::ops::{Deref, DerefMut};
+use std::task::{Context, Poll};
+use tonic::transport::{Body, NamedService};
+use tonic::{body::BoxBody, codegen::Service};
+use tracing_futures::Instrument;
+
+use crate::RequestId;
+
+/// Use in tonic server context,
+/// so that your service automatically extracts the request id from incoming requests.
+///
+/// Please note that the request id could still be missing,
+/// e.g. if an incoming grpc request was made without setting the request id.
+#[derive(Debug, Clone)]
+pub struct RelayService<S> {
+    inner: S,
+}
+
+impl<S> RelayService<S> {
+    pub fn new(inner: S) -> Self {
+        Self { inner }
+    }
+}
+
+impl<S: NamedService> NamedService for RelayService<S> {
+    const NAME: &'static str = S::NAME;
+}
+
+impl<S> Deref for RelayService<S> {
+    type Target = S;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<S> DerefMut for RelayService<S> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl<S> Service<Request<Body>> for RelayService<S>
+where
+    S: Service<Request<Body>, Response = Response<BoxBody>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<Body>) -> Self::Future {
+        let mut svc = self.inner.clone();
+
+        let request_id = RequestId::try_from(&req) // search for a value (e.g. relayed by another server)
+            .unwrap_or_else(|_| RequestId::generate()); // provide a value if not found (e.g. direct incoming request)
+
+        // TODO: modularity + similar implementation with main feature
+        let span = tracing::info_span!(
+            "Request",
+            request_id = %request_id.clone(),
+            request_method = %req.method(),
+            request_version = %match req.version() {
+              hyper::Version::HTTP_09 => "0.9".to_string(),
+              hyper::Version::HTTP_10 => "1.0".to_string(),
+              hyper::Version::HTTP_11 => "1.1".to_string(),
+              hyper::Version::HTTP_2 => "2.0".to_string(),
+              hyper::Version::HTTP_3 => "3.0".to_string(),
+              other => format!("{:?}", other),
+            },
+            request_uri = %req.uri(),
+        );
+        // safety: must always be set prior first read
+        let fut = super::REQUEST_ID.sync_scope(request_id.clone(), move || svc.call(req));
+        Box::pin(
+            super::REQUEST_ID
+                .scope(request_id, async move { fut.await })
+                .instrument(span),
+        )
+    }
+}


### PR DESCRIPTION
Hey @LukeMathWalker here it is, following issue #53.

I just did the basic implementation + working `example`,
so that you can appreciate if it's a good candidate for `tracing-actix-web` or not (no hard feelings if you don't).

There's some more work to do in order to allow `RelayService` to be configured like `TracingLogger` (implementing `RootSpanBuilder` properly, maybe using `root_span_macro`) that I'm willing to do if you think this PR is worth it.

Basically this PR would add `relay` feature, which is just a convenient way to propagate `request_id` across gRPC calls.
It brings:
- `Relay` actix middleware (to internally expose `request_id` via `tokio::task_local!`)
- `RelayInterceptor` (to automatically append `request_id` to a gRPC client requests metadata)
- `RelayService` (to automatically extract `request_id` from incoming gRPC requests metadata)

Thanks for your time :relieved:

