### PR TITLE
Updated actix-web dependency to `4.0.0-beta.18`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ opentelemetry_0_16 = ["opentelemetry_0_16_pkg", "tracing-opentelemetry_0_16_pkg"
 emit_event_on_error = []
 
 [dependencies]
-actix-web = { version = "=4.0.0-beta.16", default-features = false }
+actix-web = { version = "=4.0.0-beta.18", default-features = false }
 pin-project = "1.0.0"
 tracing = "0.1.19"
 tracing-futures = "0.2.4"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Add `tracing-actix-web` to your dependencies:
 # ...
 tracing-actix-web = "0.5.0-beta.7"
 tracing = "0.1"
-actix-web = "4.0.0-beta.16"
+actix-web = "4.0.0-beta.18"
 ```
 
 `tracing-actix-web` exposes three feature flags:

--- a/examples/custom-root-span/Cargo.toml
+++ b/examples/custom-root-span/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix-web = "=4.0.0-beta.16"
+actix-web = "=4.0.0-beta.18"
 opentelemetry = { version = "0.16", features = ["rt-tokio-current-thread"] }
 opentelemetry-jaeger = { version = "0.15", features = ["rt-tokio-current-thread"] }
 tracing-opentelemetry = { version = "0.16" }

--- a/examples/opentelemetry/Cargo.toml
+++ b/examples/opentelemetry/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-actix-web = "=4.0.0-beta.16"
+actix-web = "=4.0.0-beta.18"
 tracing = "0.1.19"
 opentelemetry = { version = "0.16", features = ["rt-tokio-current-thread"] }
 opentelemetry-jaeger = { version = "0.15", features = ["rt-tokio-current-thread"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! # ...
 //! tracing-actix-web = "0.5.0-beta.7"
 //! tracing = "0.1"
-//! actix-web = "4.0.0-beta.16"
+//! actix-web = "4.0.0-beta.18"
 //! ```
 //!
 //! `tracing-actix-web` exposes three feature flags:


### PR DESCRIPTION
Feels weird to pin the dep in a library. I feel that it should be delegated to the end consumer.