### PR TITLE
Add support for opentelemetry 0.17, actix-web rc.2

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -52,6 +52,7 @@ jobs:
           - opentelemetry_0_14
           - opentelemetry_0_15
           - opentelemetry_0_16
+          - opentelemetry_0_17
     steps:
       - uses: actions/checkout@v2
       - name: Cache dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ tracing-opentelemetry_0_16_pkg = { package = "tracing-opentelemetry",version = "
 tracing-opentelemetry_0_17_pkg = { package = "tracing-opentelemetry",version = "0.17", optional = true }
 
 [dev-dependencies]
+actix-web = { version = "=4.0.0-rc.2", default-features = false, features = ["macros"] }
 tracing-subscriber = { version = "0.3.0", features = ["registry", "env-filter"] }
 tracing-bunyan-formatter = "0.3.0"
 tracing-log = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "examples/opentelemetry", "examples/custom-root-span"]
 
 [package]
 name = "tracing-actix-web"
-version = "0.5.0-rc.1"
+version = "0.5.0-rc.2"
 authors = ["Luca Palmieri <rust@lpalmieri.com>"]
 edition = "2018"
 
@@ -24,10 +24,11 @@ opentelemetry_0_13 = ["opentelemetry_0_13_pkg", "tracing-opentelemetry_0_12_pkg"
 opentelemetry_0_14 = ["opentelemetry_0_14_pkg", "tracing-opentelemetry_0_13_pkg"]
 opentelemetry_0_15 = ["opentelemetry_0_15_pkg", "tracing-opentelemetry_0_14_pkg"]
 opentelemetry_0_16 = ["opentelemetry_0_16_pkg", "tracing-opentelemetry_0_16_pkg"]
+opentelemetry_0_17 = ["opentelemetry_0_17_pkg", "tracing-opentelemetry_0_17_pkg"]
 emit_event_on_error = []
 
 [dependencies]
-actix-web = { version = "=4.0.0-rc.1", default-features = false }
+actix-web = { version = "=4.0.0-rc.2", default-features = false }
 pin-project = "1.0.0"
 tracing = "0.1.19"
 tracing-futures = "0.2.4"
@@ -36,10 +37,12 @@ opentelemetry_0_13_pkg = { package = "opentelemetry", version = "0.13", optional
 opentelemetry_0_14_pkg = { package = "opentelemetry", version = "0.14", optional = true }
 opentelemetry_0_15_pkg = { package = "opentelemetry", version = "0.15", optional = true }
 opentelemetry_0_16_pkg = { package = "opentelemetry", version = "0.16", optional = true }
+opentelemetry_0_17_pkg = { package = "opentelemetry", version = "0.17", optional = true }
 tracing-opentelemetry_0_12_pkg = { package = "tracing-opentelemetry",version = "0.12", optional = true }
 tracing-opentelemetry_0_13_pkg = { package = "tracing-opentelemetry", version = "0.13", optional = true }
 tracing-opentelemetry_0_14_pkg = { package = "tracing-opentelemetry",version = "0.14", optional = true }
 tracing-opentelemetry_0_16_pkg = { package = "tracing-opentelemetry",version = "0.16", optional = true }
+tracing-opentelemetry_0_17_pkg = { package = "tracing-opentelemetry",version = "0.17", optional = true }
 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.0", features = ["registry", "env-filter"] }

--- a/README.md
+++ b/README.md
@@ -257,10 +257,10 @@ To fulfill a request you often have to perform additional I/O operations - e.g. 
 `tracing-actix-web` provides support for distributed tracing by supporting the [OpenTelemetry standard](https://opentelemetry.io/).  
 `tracing-actix-web` follows [OpenTelemetry's semantic convention](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#spancontext)
 for field names.  
-Furthermore, it provides an `opentelemetry_0_16` feature flag to automatically performs trace propagation: it tries to extract the OpenTelemetry context out of the headers of incoming requests and, when it finds one, it sets it as the remote context for the current root span. The context is then propagated to your downstream dependencies if your HTTP or gRPC clients are OpenTelemetry-aware - e.g. using [`reqwest-middleware` and `reqwest-tracing`](https://github.com/TrueLayer/reqwest-middleware) if you are using `reqwest` as your HTTP client.  
+Furthermore, it provides an `opentelemetry_0_17` feature flag to automatically performs trace propagation: it tries to extract the OpenTelemetry context out of the headers of incoming requests and, when it finds one, it sets it as the remote context for the current root span. The context is then propagated to your downstream dependencies if your HTTP or gRPC clients are OpenTelemetry-aware - e.g. using [`reqwest-middleware` and `reqwest-tracing`](https://github.com/TrueLayer/reqwest-middleware) if you are using `reqwest` as your HTTP client.  
 You can then find all logs for the same request across all the services it touched by looking for the `trace_id`, automatically logged by `tracing-actix-web`.
 
-If you add [`tracing-opentelemetry::OpenTelemetryLayer`](https://docs.rs/tracing-opentelemetry/0.16.0/tracing_opentelemetry/struct.OpenTelemetryLayer.html)
+If you add [`tracing-opentelemetry::OpenTelemetryLayer`](https://docs.rs/tracing-opentelemetry/0.17.0/tracing_opentelemetry/struct.OpenTelemetryLayer.html)
 in your `tracing::Subscriber` you will be able to export the root span (and all its children) as OpenTelemetry spans.
 
 Check out the [relevant example in the GitHub repository](https://github.com/LukeMathWalker/tracing-actix-web/tree/main/examples/opentelemetry) for reference.

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Add `tracing-actix-web` to your dependencies:
 ```toml
 [dependencies]
 # ...
-tracing-actix-web = "=0.5.0-rc.1"
+tracing-actix-web = "=0.5.0-rc.2"
 tracing = "0.1"
-actix-web = "=4.0.0-rc.1"
+actix-web = "=4.0.0-rc.2"
 ```
 
 `tracing-actix-web` exposes three feature flags:
@@ -48,6 +48,7 @@ actix-web = "=4.0.0-rc.1"
 - `opentelemetry_0_14`: same as above but using `opentelemetry` 0.14;
 - `opentelemetry_0_15`: same as above but using `opentelemetry` 0.15;
 - `opentelemetry_0_16`: same as above but using `opentelemetry` 0.16;
+- `opentelemetry_0_17`: same as above but using `opentelemetry` 0.17;
 - `emit_event_on_error`: emit a [`tracing`] event when request processing fails with an error (enabled by default).
 
 `tracing-actix-web` will release `0.5.0`, going out of beta, as soon as `actix-web` releases a stable `4.0.0`.

--- a/examples/custom-root-span/Cargo.toml
+++ b/examples/custom-root-span/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix-web = "=4.0.0-rc.1"
-opentelemetry = { version = "0.16", features = ["rt-tokio-current-thread"] }
-opentelemetry-jaeger = { version = "0.15", features = ["rt-tokio-current-thread"] }
-tracing-opentelemetry = { version = "0.16" }
+actix-web = "=4.0.0-rc.2"
+opentelemetry = { version = "0.17", features = ["rt-tokio-current-thread"] }
+opentelemetry-jaeger = { version = "0.16", features = ["rt-tokio-current-thread"] }
+tracing-opentelemetry = { version = "0.17" }
 tracing = "0.1.19"
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
 tracing-bunyan-formatter = "0.3"

--- a/examples/opentelemetry/Cargo.toml
+++ b/examples/opentelemetry/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2018"
 license = "MIT/Apache-2.0"
 
 [dependencies]
-actix-web = "=4.0.0-rc.1"
+actix-web = "=4.0.0-rc.2"
 tracing = "0.1.19"
-opentelemetry = { version = "0.16", features = ["rt-tokio-current-thread"] }
-opentelemetry-jaeger = { version = "0.15", features = ["rt-tokio-current-thread"] }
-tracing-opentelemetry = { version = "0.16" }
+opentelemetry = { version = "0.17", features = ["rt-tokio-current-thread"] }
+opentelemetry-jaeger = { version = "0.16", features = ["rt-tokio-current-thread"] }
+tracing-opentelemetry = { version = "0.17" }
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
 tracing-bunyan-formatter = "0.3"
-tracing-actix-web = { path = "../..", features = ["opentelemetry_0_16"] }
+tracing-actix-web = { path = "../..", features = ["opentelemetry_0_17"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,9 @@
 //! ```toml
 //! [dependencies]
 //! # ...
-//! tracing-actix-web = "=0.5.0-rc.1"
+//! tracing-actix-web = "=0.5.0-rc.2"
 //! tracing = "0.1"
-//! actix-web = "=4.0.0-rc.1"
+//! actix-web = "=4.0.0-rc.2"
 //! ```
 //!
 //! `tracing-actix-web` exposes three feature flags:
@@ -21,6 +21,7 @@
 //! - `opentelemetry_0_14`: same as above but using `opentelemetry` 0.14;
 //! - `opentelemetry_0_15`: same as above but using `opentelemetry` 0.15;
 //! - `opentelemetry_0_16`: same as above but using `opentelemetry` 0.16;
+//! - `opentelemetry_0_17`: same as above but using `opentelemetry` 0.17;
 //! - `emit_event_on_error`: emit a [`tracing`] event when request processing fails with an error (enabled by default).
 //!
 //! `tracing-actix-web` will release `0.5.0`, going out of beta, as soon as `actix-web` releases a stable `4.0.0`.
@@ -225,10 +226,10 @@
 //! `tracing-actix-web` provides support for distributed tracing by supporting the [OpenTelemetry standard](https://opentelemetry.io/).  
 //! `tracing-actix-web` follows [OpenTelemetry's semantic convention](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#spancontext)
 //! for field names.
-//! Furthermore, it provides an `opentelemetry_0_16` feature flag to automatically performs trace propagation: it tries to extract the OpenTelemetry context out of the headers of incoming requests and, when it finds one, it sets it as the remote context for the current root span. The context is then propagated to your downstream dependencies if your HTTP or gRPC clients are OpenTelemetry-aware - e.g. using [`reqwest-middleware` and `reqwest-tracing`](https://github.com/TrueLayer/reqwest-middleware) if you are using `reqwest` as your HTTP client.  
+//! Furthermore, it provides an `opentelemetry_0_17` feature flag to automatically performs trace propagation: it tries to extract the OpenTelemetry context out of the headers of incoming requests and, when it finds one, it sets it as the remote context for the current root span. The context is then propagated to your downstream dependencies if your HTTP or gRPC clients are OpenTelemetry-aware - e.g. using [`reqwest-middleware` and `reqwest-tracing`](https://github.com/TrueLayer/reqwest-middleware) if you are using `reqwest` as your HTTP client.  
 //! You can then find all logs for the same request across all the services it touched by looking for the `trace_id`, automatically logged by `tracing-actix-web`.
 //!
-//! If you add [`tracing-opentelemetry::OpenTelemetryLayer`](https://docs.rs/tracing-opentelemetry/0.16.0/tracing_opentelemetry/struct.OpenTelemetryLayer.html)
+//! If you add [`tracing-opentelemetry::OpenTelemetryLayer`](https://docs.rs/tracing-opentelemetry/0.17.0/tracing_opentelemetry/struct.OpenTelemetryLayer.html)
 //! in your `tracing::Subscriber` you will be able to export the root span (and all its children) as OpenTelemetry spans.
 //!
 //! Check out the [relevant example in the GitHub repository](https://github.com/LukeMathWalker/tracing-actix-web/tree/main/examples/opentelemetry) for reference.
@@ -252,7 +253,8 @@ pub mod root_span_macro;
     feature = "opentelemetry_0_13",
     feature = "opentelemetry_0_14",
     feature = "opentelemetry_0_15",
-    feature = "opentelemetry_0_16"
+    feature = "opentelemetry_0_16",
+    feature = "opentelemetry_0_17"
 ))]
 mod otel;
 
@@ -265,11 +267,23 @@ compile_error!("feature \"opentelemetry_0_13\" and feature \"opentelemetry_0_15\
 #[cfg(all(feature = "opentelemetry_0_13", feature = "opentelemetry_0_16"))]
 compile_error!("feature \"opentelemetry_0_13\" and feature \"opentelemetry_0_16\" cannot be enabled at the same time");
 
+#[cfg(all(feature = "opentelemetry_0_13", feature = "opentelemetry_0_17"))]
+compile_error!("feature \"opentelemetry_0_13\" and feature \"opentelemetry_0_17\" cannot be enabled at the same time");
+
 #[cfg(all(feature = "opentelemetry_0_14", feature = "opentelemetry_0_15"))]
 compile_error!("feature \"opentelemetry_0_14\" and feature \"opentelemetry_0_15\" cannot be enabled at the same time");
 
 #[cfg(all(feature = "opentelemetry_0_14", feature = "opentelemetry_0_16"))]
 compile_error!("feature \"opentelemetry_0_14\" and feature \"opentelemetry_0_16\" cannot be enabled at the same time");
 
+#[cfg(all(feature = "opentelemetry_0_14", feature = "opentelemetry_0_17"))]
+compile_error!("feature \"opentelemetry_0_14\" and feature \"opentelemetry_0_17\" cannot be enabled at the same time");
+
 #[cfg(all(feature = "opentelemetry_0_15", feature = "opentelemetry_0_16"))]
 compile_error!("feature \"opentelemetry_0_15\" and feature \"opentelemetry_0_16\" cannot be enabled at the same time");
+
+#[cfg(all(feature = "opentelemetry_0_15", feature = "opentelemetry_0_17"))]
+compile_error!("feature \"opentelemetry_0_15\" and feature \"opentelemetry_0_17\" cannot be enabled at the same time");
+
+#[cfg(all(feature = "opentelemetry_0_16", feature = "opentelemetry_0_17"))]
+compile_error!("feature \"opentelemetry_0_16\" and feature \"opentelemetry_0_17\" cannot be enabled at the same time");

--- a/src/otel.rs
+++ b/src/otel.rs
@@ -8,6 +8,8 @@ use opentelemetry_0_14_pkg as opentelemetry;
 use opentelemetry_0_15_pkg as opentelemetry;
 #[cfg(feature = "opentelemetry_0_16")]
 use opentelemetry_0_16_pkg as opentelemetry;
+#[cfg(feature = "opentelemetry_0_17")]
+use opentelemetry_0_17_pkg as opentelemetry;
 
 #[cfg(feature = "opentelemetry_0_13")]
 use tracing_opentelemetry_0_12_pkg as tracing_opentelemetry;
@@ -17,6 +19,8 @@ use tracing_opentelemetry_0_13_pkg as tracing_opentelemetry;
 use tracing_opentelemetry_0_14_pkg as tracing_opentelemetry;
 #[cfg(feature = "opentelemetry_0_16")]
 use tracing_opentelemetry_0_16_pkg as tracing_opentelemetry;
+#[cfg(feature = "opentelemetry_0_17")]
+use tracing_opentelemetry_0_17_pkg as tracing_opentelemetry;
 
 use opentelemetry::propagation::Extractor;
 
@@ -50,6 +54,14 @@ pub(crate) fn set_otel_parent(req: &ServiceRequest, span: &tracing::Span) {
     span.set_parent(parent_context);
     // If we have a remote parent span, this will be the parent's trace identifier.
     // If not, it will be the newly generated trace identifier with this request as root span.
+    #[cfg(not(feature = "opentelemetry_0_17"))]
     let trace_id = span.context().span().span_context().trace_id().to_hex();
+
+    #[cfg(feature = "opentelemetry_0_17")]
+    let trace_id = {
+        let id = span.context().span().span_context().trace_id();
+        format!("{:032x}", id)
+    };
+
     span.record("trace_id", &tracing::field::display(trace_id));
 }

--- a/src/root_span_macro.rs
+++ b/src/root_span_macro.rs
@@ -132,7 +132,8 @@ pub mod private {
             feature = "opentelemetry_0_13",
             feature = "opentelemetry_0_14",
             feature = "opentelemetry_0_15",
-            feature = "opentelemetry_0_16"
+            feature = "opentelemetry_0_16",
+            feature = "opentelemetry_0_17"
         ))]
         crate::otel::set_otel_parent(req, span);
     }


### PR DESCRIPTION
there's no longer a `.to_hex()` method on `TraceId`, but I pulled the format string it used from 0.16 directly into the `otel.rs` file