### PR TITLE
Add otel.name field to the root span

### DIFF
--- a/src/root_span_macro.rs
+++ b/src/root_span_macro.rs
@@ -86,6 +86,7 @@ macro_rules! root_span {
                 http.user_agent = %user_agent,
                 http.target = %$request.uri().path_and_query().map(|p| p.as_str()).unwrap_or(""),
                 http.status_code = $crate::root_span_macro::private::tracing::field::Empty,
+                otel.name = %format!("HTTP {} {}", http_method, http_route),
                 otel.kind = "server",
                 otel.status_code = $crate::root_span_macro::private::tracing::field::Empty,
                 trace_id = $crate::root_span_macro::private::tracing::field::Empty,


### PR DESCRIPTION
Add the otel.name field to the root span with the `HTTP {method} {path}` format, following the [otel guidelines] on span names (https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md).

It overrides the `HTTP Request` span name set for the `tracing` span when exporting opentelemetry data and is a lot more readable in UIs like Jaeger, for example with the provided demo:

![image](https://user-images.githubusercontent.com/44224782/156026863-ec234643-0826-4074-90ab-471b7ded31d4.png)

Questions:
- I'm not sure if we should go with `HTTP {method} {path}` or just `{method} {path}`, but if the app also receives other types of requests it might be better to be explicit.

- Is `format!` the best way way to create the string there ?


