### PR TITLE
Bound type-param of RootSpanBuilder::on_request_end

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,7 @@
 //! We could add a `client_id` property to the root span using a custom builder, `DomainRootSpanBuilder`:
 //!
 //! ```rust
+//! use actix_web::body::MessageBody;
 //! use actix_web::dev::{ServiceResponse, ServiceRequest};
 //! use actix_web::Error;
 //! use tracing_actix_web::{TracingLogger, DefaultRootSpanBuilder, RootSpanBuilder};
@@ -110,7 +111,7 @@
 //!         tracing::info_span!("Request", client_id)
 //!     }
 //!
-//!     fn on_request_end<B>(_span: Span, _outcome: &Result<ServiceResponse<B>, Error>) {}
+//!     fn on_request_end<B: MessageBody>(_span: Span, _outcome: &Result<ServiceResponse<B>, Error>) {}
 //! }
 //!
 //! let custom_middleware = TracingLogger::<DomainRootSpanBuilder>::new();
@@ -123,6 +124,7 @@
 //! We can do better!
 //!
 //! ```rust
+//! use actix_web::body::MessageBody;
 //! use actix_web::dev::{ServiceResponse, ServiceRequest};
 //! use actix_web::Error;
 //! use tracing_actix_web::{TracingLogger, DefaultRootSpanBuilder, RootSpanBuilder};
@@ -136,7 +138,7 @@
 //!         tracing_actix_web::root_span!(request, client_id)
 //!     }
 //!
-//!     fn on_request_end<B>(span: Span, outcome: &Result<ServiceResponse<B>, Error>) {
+//!     fn on_request_end<B: MessageBody>(span: Span, outcome: &Result<ServiceResponse<B>, Error>) {
 //!         DefaultRootSpanBuilder::on_request_end(span, outcome);
 //!     }
 //! }
@@ -155,6 +157,7 @@
 //! the span level:
 //!
 //! ```rust
+//! use actix_web::body::MessageBody;
 //! use actix_web::dev::{ServiceResponse, ServiceRequest};
 //! use actix_web::Error;
 //! use tracing_actix_web::{TracingLogger, DefaultRootSpanBuilder, RootSpanBuilder, Level};
@@ -172,7 +175,7 @@
 //!         tracing_actix_web::root_span!(level = level, request)
 //!     }
 //!
-//!     fn on_request_end<B>(span: Span, outcome: &Result<ServiceResponse<B>, Error>) {
+//!     fn on_request_end<B: MessageBody>(span: Span, outcome: &Result<ServiceResponse<B>, Error>) {
 //!         DefaultRootSpanBuilder::on_request_end(span, outcome);
 //!     }
 //! }
@@ -187,6 +190,7 @@
 //! to your root span as it becomes available:
 //!
 //! ```rust
+//! use actix_web::body::MessageBody;
 //! use actix_web::dev::{ServiceResponse, ServiceRequest};
 //! use actix_web::{Error, HttpResponse};
 //! use tracing_actix_web::{RootSpan, DefaultRootSpanBuilder, RootSpanBuilder};
@@ -218,7 +222,7 @@
 //!         )
 //!     }
 //!
-//!     fn on_request_end<B>(span: Span, response: &Result<ServiceResponse<B>, Error>) {
+//!     fn on_request_end<B: MessageBody>(span: Span, response: &Result<ServiceResponse<B>, Error>) {
 //!         DefaultRootSpanBuilder::on_request_end(span, response);
 //!     }
 //! }

--- a/src/root_span_builder.rs
+++ b/src/root_span_builder.rs
@@ -1,4 +1,5 @@
 use crate::root_span;
+use actix_web::body::MessageBody;
 use actix_web::dev::{ServiceRequest, ServiceResponse};
 use actix_web::http::StatusCode;
 use actix_web::{Error, ResponseError};
@@ -10,7 +11,7 @@ use tracing::Span;
 /// [`TracingLogger`]: crate::TracingLogger
 pub trait RootSpanBuilder {
     fn on_request_start(request: &ServiceRequest) -> Span;
-    fn on_request_end<B>(span: Span, outcome: &Result<ServiceResponse<B>, Error>);
+    fn on_request_end<B: MessageBody>(span: Span, outcome: &Result<ServiceResponse<B>, Error>);
 }
 
 /// The default [`RootSpanBuilder`] for [`TracingLogger`].
@@ -40,7 +41,7 @@ impl RootSpanBuilder for DefaultRootSpanBuilder {
         root_span!(level = crate::Level::INFO, request)
     }
 
-    fn on_request_end<B>(span: Span, outcome: &Result<ServiceResponse<B>, Error>) {
+    fn on_request_end<B: MessageBody>(span: Span, outcome: &Result<ServiceResponse<B>, Error>) {
         match &outcome {
             Ok(response) => {
                 if let Some(error) = response.response().error() {

--- a/src/root_span_macro.rs
+++ b/src/root_span_macro.rs
@@ -14,6 +14,7 @@
 /// The first argument passed to `root_span!` must be a reference to an [`actix_web::dev::ServiceRequest`].
 ///
 /// ```rust
+/// use actix_web::body::MessageBody;
 /// use actix_web::dev::{ServiceResponse, ServiceRequest};
 /// use actix_web::Error;
 /// use tracing_actix_web::{TracingLogger, DefaultRootSpanBuilder, RootSpanBuilder, root_span};
@@ -26,7 +27,7 @@
 ///         root_span!(request)
 ///     }
 ///
-///     fn on_request_end<B>(span: Span, outcome: &Result<ServiceResponse<B>, Error>) {
+///     fn on_request_end<B: MessageBody>(span: Span, outcome: &Result<ServiceResponse<B>, Error>) {
 ///         DefaultRootSpanBuilder::on_request_end(span, outcome);
 ///     }
 /// }


### PR DESCRIPTION
*Issue #, if available:* Resolves #92

*Description of changes:*
This PR bounds the type parameter of `RootSpanBuilder::on_request_end` with `actix_web::body::MessageBody`.

This doesn't directly break any use-cases, since this method is always used in cases where this bound holds (see description of #92). However, this does introduce a **breaking change** in the public API, and thus will involve bumping the minor version (since the current version is 0.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
