### PR TITLE
Fixed version number in lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! ```toml
 //! [dependencies]
 //! # ...
-//! tracing-actix-web = "0.6"
+//! tracing-actix-web = "0.7"
 //! tracing = "0.1"
 //! actix-web = "4"
 //! ```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The version used for `tracing-actix-web` in the documentation in `src/lib.rs` was set to 0.6, but the code only works with 0.7.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
