### PR TITLE
Expose StreamSpan

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,7 +273,7 @@ mod request_id;
 mod root_span;
 mod root_span_builder;
 
-pub use middleware::TracingLogger;
+pub use middleware::{StreamSpan, TracingLogger};
 pub use request_id::RequestId;
 pub use root_span::RootSpan;
 pub use root_span_builder::{DefaultRootSpanBuilder, RootSpanBuilder};


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In order to create a "build_app" function, it needs to see `StreamSpan` like so:

```rust
pub fn build_app() -> App<
    impl ServiceFactory<
        ServiceRequest,
        Config = (),
        Response = ServiceResponse<tracing_actix_web::StreamSpan<BoxBody>>,
        Error = actix_web::Error,
        InitError = (),
    >,
> { ... }
```

