### PR TITLE
Add support for OpenTelemetry 0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ opentelemetry_0_17 = ["opentelemetry_0_17_pkg", "tracing-opentelemetry_0_17_pkg"
 opentelemetry_0_18 = ["opentelemetry_0_18_pkg", "tracing-opentelemetry_0_18_pkg"]
 opentelemetry_0_19 = ["opentelemetry_0_19_pkg", "tracing-opentelemetry_0_19_pkg"]
 opentelemetry_0_20 = ["opentelemetry_0_20_pkg", "tracing-opentelemetry_0_21_pkg"]
+opentelemetry_0_21 = ["opentelemetry_0_21_pkg", "tracing-opentelemetry_0_22_pkg"]
 emit_event_on_error = []
 uuid_v7 = ["uuid/v7"]
 
@@ -44,6 +45,7 @@ opentelemetry_0_17_pkg = { package = "opentelemetry", version = "0.17", optional
 opentelemetry_0_18_pkg = { package = "opentelemetry", version = "0.18", optional = true }
 opentelemetry_0_19_pkg = { package = "opentelemetry", version = "0.19", optional = true }
 opentelemetry_0_20_pkg = { package = "opentelemetry", version = "0.20", optional = true }
+opentelemetry_0_21_pkg = { package = "opentelemetry", version = "0.21", optional = true }
 tracing-opentelemetry_0_12_pkg = { package = "tracing-opentelemetry",version = "0.12", optional = true }
 tracing-opentelemetry_0_13_pkg = { package = "tracing-opentelemetry", version = "0.13", optional = true }
 tracing-opentelemetry_0_14_pkg = { package = "tracing-opentelemetry",version = "0.14", optional = true }
@@ -52,6 +54,7 @@ tracing-opentelemetry_0_17_pkg = { package = "tracing-opentelemetry",version = "
 tracing-opentelemetry_0_18_pkg = { package = "tracing-opentelemetry",version = "0.18", optional = true }
 tracing-opentelemetry_0_19_pkg = { package = "tracing-opentelemetry",version = "0.19", optional = true }
 tracing-opentelemetry_0_21_pkg = { package = "tracing-opentelemetry",version = "0.21", optional = true }
+tracing-opentelemetry_0_22_pkg = { package = "tracing-opentelemetry",version = "0.22", optional = true }
 
 [dev-dependencies]
 actix-web = { version = "4", default-features = false, features = ["macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ actix-web = { version = "4", default-features = false }
 pin-project = "1.0.0"
 tracing = "0.1.36"
 uuid = { version = "1", features = ["v4"] }
+mutually_exclusive_features = "0.0.3"
 opentelemetry_0_13_pkg = { package = "opentelemetry", version = "0.13", optional = true }
 opentelemetry_0_14_pkg = { package = "opentelemetry", version = "0.14", optional = true }
 opentelemetry_0_15_pkg = { package = "opentelemetry", version = "0.15", optional = true }

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ actix-web = "4"
 - `opentelemetry_0_17`: same as above but using `opentelemetry` 0.17;
 - `opentelemetry_0_18`: same as above but using `opentelemetry` 0.18;
 - `opentelemetry_0_19`: same as above but using `opentelemetry` 0.19;
+- `opentelemetry_0_20`: same as above but using `opentelemetry` 0.20;
+- `opentelemetry_0_21`: same as above but using `opentelemetry` 0.21;
 - `emit_event_on_error`: emit a [`tracing`] event when request processing fails with an error (enabled by default).
 - `uuid_v7`: use the UUID v7 implementation inside [`RequestId`] instead of UUID v4 (disabled by default).
 ## Quickstart

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,6 +293,18 @@ pub use tracing::Level;
 #[doc(hidden)]
 pub mod root_span_macro;
 
+mutually_exclusive_features::none_or_one_of!(
+    "opentelemetry_0_13",
+    "opentelemetry_0_14",
+    "opentelemetry_0_15",
+    "opentelemetry_0_16",
+    "opentelemetry_0_17",
+    "opentelemetry_0_18",
+    "opentelemetry_0_19",
+    "opentelemetry_0_20",
+    "opentelemetry_0_21",
+);
+
 #[cfg(any(
     feature = "opentelemetry_0_13",
     feature = "opentelemetry_0_14",
@@ -305,35 +317,3 @@ pub mod root_span_macro;
     feature = "opentelemetry_0_21",
 ))]
 mod otel;
-
-const _OTEL_GUARD: () = assert!({
-    let mut enabled_count = 0;
-    if cfg!(feature = "opentelemetry_0_13") {
-        enabled_count += 1;
-    }
-    if cfg!(feature = "opentelemetry_0_14") {
-        enabled_count += 1;
-    }
-    if cfg!(feature = "opentelemetry_0_15") {
-        enabled_count += 1;
-    }
-    if cfg!(feature = "opentelemetry_0_16") {
-        enabled_count += 1;
-    }
-    if cfg!(feature = "opentelemetry_0_17") {
-        enabled_count += 1;
-    }
-    if cfg!(feature = "opentelemetry_0_18") {
-        enabled_count += 1;
-    }
-    if cfg!(feature = "opentelemetry_0_19") {
-        enabled_count += 1;
-    }
-    if cfg!(feature = "opentelemetry_0_20") {
-        enabled_count += 1;
-    }
-    if cfg!(feature = "opentelemetry_0_21") {
-        enabled_count += 1;
-    }
-    enabled_count <= 1
-}, "Only one `opentelemetry_*` feature can be enabled at the same time.");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,7 +302,7 @@ pub mod root_span_macro;
     feature = "opentelemetry_0_18",
     feature = "opentelemetry_0_19",
     feature = "opentelemetry_0_20",
-    feature = "opentelemetry_0_21"
+    feature = "opentelemetry_0_21",
 ))]
 mod otel;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -306,110 +306,34 @@ pub mod root_span_macro;
 ))]
 mod otel;
 
-#[cfg(all(feature = "opentelemetry_0_13", feature = "opentelemetry_0_14"))]
-compile_error!("feature \"opentelemetry_0_13\" and feature \"opentelemetry_0_14\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_13", feature = "opentelemetry_0_15"))]
-compile_error!("feature \"opentelemetry_0_13\" and feature \"opentelemetry_0_15\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_13", feature = "opentelemetry_0_16"))]
-compile_error!("feature \"opentelemetry_0_13\" and feature \"opentelemetry_0_16\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_13", feature = "opentelemetry_0_17"))]
-compile_error!("feature \"opentelemetry_0_13\" and feature \"opentelemetry_0_17\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_13", feature = "opentelemetry_0_18"))]
-compile_error!("feature \"opentelemetry_0_13\" and feature \"opentelemetry_0_18\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_13", feature = "opentelemetry_0_19"))]
-compile_error!("feature \"opentelemetry_0_13\" and feature \"opentelemetry_0_19\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_13", feature = "opentelemetry_0_20"))]
-compile_error!("feature \"opentelemetry_0_13\" and feature \"opentelemetry_0_20\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_13", feature = "opentelemetry_0_21"))]
-compile_error!("feature \"opentelemetry_0_13\" and feature \"opentelemetry_0_21\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_14", feature = "opentelemetry_0_15"))]
-compile_error!("feature \"opentelemetry_0_14\" and feature \"opentelemetry_0_15\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_14", feature = "opentelemetry_0_16"))]
-compile_error!("feature \"opentelemetry_0_14\" and feature \"opentelemetry_0_16\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_14", feature = "opentelemetry_0_17"))]
-compile_error!("feature \"opentelemetry_0_14\" and feature \"opentelemetry_0_17\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_14", feature = "opentelemetry_0_18"))]
-compile_error!("feature \"opentelemetry_0_14\" and feature \"opentelemetry_0_18\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_14", feature = "opentelemetry_0_19"))]
-compile_error!("feature \"opentelemetry_0_14\" and feature \"opentelemetry_0_19\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_14", feature = "opentelemetry_0_20"))]
-compile_error!("feature \"opentelemetry_0_14\" and feature \"opentelemetry_0_20\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_14", feature = "opentelemetry_0_21"))]
-compile_error!("feature \"opentelemetry_0_14\" and feature \"opentelemetry_0_21\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_15", feature = "opentelemetry_0_16"))]
-compile_error!("feature \"opentelemetry_0_15\" and feature \"opentelemetry_0_16\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_15", feature = "opentelemetry_0_17"))]
-compile_error!("feature \"opentelemetry_0_15\" and feature \"opentelemetry_0_17\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_15", feature = "opentelemetry_0_18"))]
-compile_error!("feature \"opentelemetry_0_15\" and feature \"opentelemetry_0_18\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_15", feature = "opentelemetry_0_19"))]
-compile_error!("feature \"opentelemetry_0_15\" and feature \"opentelemetry_0_19\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_15", feature = "opentelemetry_0_20"))]
-compile_error!("feature \"opentelemetry_0_15\" and feature \"opentelemetry_0_20\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_15", feature = "opentelemetry_0_21"))]
-compile_error!("feature \"opentelemetry_0_15\" and feature \"opentelemetry_0_21\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_16", feature = "opentelemetry_0_17"))]
-compile_error!("feature \"opentelemetry_0_16\" and feature \"opentelemetry_0_17\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_16", feature = "opentelemetry_0_18"))]
-compile_error!("feature \"opentelemetry_0_16\" and feature \"opentelemetry_0_18\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_16", feature = "opentelemetry_0_19"))]
-compile_error!("feature \"opentelemetry_0_16\" and feature \"opentelemetry_0_19\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_16", feature = "opentelemetry_0_20"))]
-compile_error!("feature \"opentelemetry_0_16\" and feature \"opentelemetry_0_20\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_16", feature = "opentelemetry_0_21"))]
-compile_error!("feature \"opentelemetry_0_16\" and feature \"opentelemetry_0_21\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_17", feature = "opentelemetry_0_18"))]
-compile_error!("feature \"opentelemetry_0_17\" and feature \"opentelemetry_0_18\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_17", feature = "opentelemetry_0_19"))]
-compile_error!("feature \"opentelemetry_0_17\" and feature \"opentelemetry_0_19\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_17", feature = "opentelemetry_0_20"))]
-compile_error!("feature \"opentelemetry_0_17\" and feature \"opentelemetry_0_20\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_17", feature = "opentelemetry_0_21"))]
-compile_error!("feature \"opentelemetry_0_17\" and feature \"opentelemetry_0_21\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_18", feature = "opentelemetry_0_19"))]
-compile_error!("feature \"opentelemetry_0_18\" and feature \"opentelemetry_0_19\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_18", feature = "opentelemetry_0_20"))]
-compile_error!("feature \"opentelemetry_0_18\" and feature \"opentelemetry_0_20\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_18", feature = "opentelemetry_0_21"))]
-compile_error!("feature \"opentelemetry_0_18\" and feature \"opentelemetry_0_21\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_19", feature = "opentelemetry_0_20"))]
-compile_error!("feature \"opentelemetry_0_19\" and feature \"opentelemetry_0_20\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_19", feature = "opentelemetry_0_21"))]
-compile_error!("feature \"opentelemetry_0_19\" and feature \"opentelemetry_0_21\" cannot be enabled at the same time");
-
-#[cfg(all(feature = "opentelemetry_0_20", feature = "opentelemetry_0_21"))]
-compile_error!("feature \"opentelemetry_0_20\" and feature \"opentelemetry_0_21\" cannot be enabled at the same time");
+const _OTEL_GUARD: () = assert!({
+    let mut enabled_count = 0;
+    if cfg!(feature = "opentelemetry_0_13") {
+        enabled_count += 1;
+    }
+    if cfg!(feature = "opentelemetry_0_14") {
+        enabled_count += 1;
+    }
+    if cfg!(feature = "opentelemetry_0_15") {
+        enabled_count += 1;
+    }
+    if cfg!(feature = "opentelemetry_0_16") {
+        enabled_count += 1;
+    }
+    if cfg!(feature = "opentelemetry_0_17") {
+        enabled_count += 1;
+    }
+    if cfg!(feature = "opentelemetry_0_18") {
+        enabled_count += 1;
+    }
+    if cfg!(feature = "opentelemetry_0_19") {
+        enabled_count += 1;
+    }
+    if cfg!(feature = "opentelemetry_0_20") {
+        enabled_count += 1;
+    }
+    if cfg!(feature = "opentelemetry_0_21") {
+        enabled_count += 1;
+    }
+    enabled_count <= 1
+}, "Only one `opentelemetry_*` feature can be enabled at the same time.");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@
 //! - `opentelemetry_0_18`: same as above but using `opentelemetry` 0.18;
 //! - `opentelemetry_0_19`: same as above but using `opentelemetry` 0.19;
 //! - `opentelemetry_0_20`: same as above but using `opentelemetry` 0.20;
+//! - `opentelemetry_0_21`: same as above but using `opentelemetry` 0.21;
 //! - `emit_event_on_error`: emit a [`tracing`] event when request processing fails with an error (enabled by default).
 //! - `uuid_v7`: use the UUID v7 implementation inside [`RequestId`] instead of UUID v4 (disabled by default).
 //!
@@ -300,7 +301,8 @@ pub mod root_span_macro;
     feature = "opentelemetry_0_17",
     feature = "opentelemetry_0_18",
     feature = "opentelemetry_0_19",
-    feature = "opentelemetry_0_20"
+    feature = "opentelemetry_0_20",
+    feature = "opentelemetry_0_21"
 ))]
 mod otel;
 
@@ -325,6 +327,9 @@ compile_error!("feature \"opentelemetry_0_13\" and feature \"opentelemetry_0_19\
 #[cfg(all(feature = "opentelemetry_0_13", feature = "opentelemetry_0_20"))]
 compile_error!("feature \"opentelemetry_0_13\" and feature \"opentelemetry_0_20\" cannot be enabled at the same time");
 
+#[cfg(all(feature = "opentelemetry_0_13", feature = "opentelemetry_0_21"))]
+compile_error!("feature \"opentelemetry_0_13\" and feature \"opentelemetry_0_21\" cannot be enabled at the same time");
+
 #[cfg(all(feature = "opentelemetry_0_14", feature = "opentelemetry_0_15"))]
 compile_error!("feature \"opentelemetry_0_14\" and feature \"opentelemetry_0_15\" cannot be enabled at the same time");
 
@@ -343,6 +348,9 @@ compile_error!("feature \"opentelemetry_0_14\" and feature \"opentelemetry_0_19\
 #[cfg(all(feature = "opentelemetry_0_14", feature = "opentelemetry_0_20"))]
 compile_error!("feature \"opentelemetry_0_14\" and feature \"opentelemetry_0_20\" cannot be enabled at the same time");
 
+#[cfg(all(feature = "opentelemetry_0_14", feature = "opentelemetry_0_21"))]
+compile_error!("feature \"opentelemetry_0_14\" and feature \"opentelemetry_0_21\" cannot be enabled at the same time");
+
 #[cfg(all(feature = "opentelemetry_0_15", feature = "opentelemetry_0_16"))]
 compile_error!("feature \"opentelemetry_0_15\" and feature \"opentelemetry_0_16\" cannot be enabled at the same time");
 
@@ -358,6 +366,9 @@ compile_error!("feature \"opentelemetry_0_15\" and feature \"opentelemetry_0_19\
 #[cfg(all(feature = "opentelemetry_0_15", feature = "opentelemetry_0_20"))]
 compile_error!("feature \"opentelemetry_0_15\" and feature \"opentelemetry_0_20\" cannot be enabled at the same time");
 
+#[cfg(all(feature = "opentelemetry_0_15", feature = "opentelemetry_0_21"))]
+compile_error!("feature \"opentelemetry_0_15\" and feature \"opentelemetry_0_21\" cannot be enabled at the same time");
+
 #[cfg(all(feature = "opentelemetry_0_16", feature = "opentelemetry_0_17"))]
 compile_error!("feature \"opentelemetry_0_16\" and feature \"opentelemetry_0_17\" cannot be enabled at the same time");
 
@@ -370,6 +381,9 @@ compile_error!("feature \"opentelemetry_0_16\" and feature \"opentelemetry_0_19\
 #[cfg(all(feature = "opentelemetry_0_16", feature = "opentelemetry_0_20"))]
 compile_error!("feature \"opentelemetry_0_16\" and feature \"opentelemetry_0_20\" cannot be enabled at the same time");
 
+#[cfg(all(feature = "opentelemetry_0_16", feature = "opentelemetry_0_21"))]
+compile_error!("feature \"opentelemetry_0_16\" and feature \"opentelemetry_0_21\" cannot be enabled at the same time");
+
 #[cfg(all(feature = "opentelemetry_0_17", feature = "opentelemetry_0_18"))]
 compile_error!("feature \"opentelemetry_0_17\" and feature \"opentelemetry_0_18\" cannot be enabled at the same time");
 
@@ -379,11 +393,23 @@ compile_error!("feature \"opentelemetry_0_17\" and feature \"opentelemetry_0_19\
 #[cfg(all(feature = "opentelemetry_0_17", feature = "opentelemetry_0_20"))]
 compile_error!("feature \"opentelemetry_0_17\" and feature \"opentelemetry_0_20\" cannot be enabled at the same time");
 
+#[cfg(all(feature = "opentelemetry_0_17", feature = "opentelemetry_0_21"))]
+compile_error!("feature \"opentelemetry_0_17\" and feature \"opentelemetry_0_21\" cannot be enabled at the same time");
+
 #[cfg(all(feature = "opentelemetry_0_18", feature = "opentelemetry_0_19"))]
 compile_error!("feature \"opentelemetry_0_18\" and feature \"opentelemetry_0_19\" cannot be enabled at the same time");
 
 #[cfg(all(feature = "opentelemetry_0_18", feature = "opentelemetry_0_20"))]
 compile_error!("feature \"opentelemetry_0_18\" and feature \"opentelemetry_0_20\" cannot be enabled at the same time");
 
+#[cfg(all(feature = "opentelemetry_0_18", feature = "opentelemetry_0_21"))]
+compile_error!("feature \"opentelemetry_0_18\" and feature \"opentelemetry_0_21\" cannot be enabled at the same time");
+
 #[cfg(all(feature = "opentelemetry_0_19", feature = "opentelemetry_0_20"))]
 compile_error!("feature \"opentelemetry_0_19\" and feature \"opentelemetry_0_20\" cannot be enabled at the same time");
+
+#[cfg(all(feature = "opentelemetry_0_19", feature = "opentelemetry_0_21"))]
+compile_error!("feature \"opentelemetry_0_19\" and feature \"opentelemetry_0_21\" cannot be enabled at the same time");
+
+#[cfg(all(feature = "opentelemetry_0_20", feature = "opentelemetry_0_21"))]
+compile_error!("feature \"opentelemetry_0_20\" and feature \"opentelemetry_0_21\" cannot be enabled at the same time");

--- a/src/otel.rs
+++ b/src/otel.rs
@@ -16,6 +16,8 @@ use opentelemetry_0_18_pkg as opentelemetry;
 use opentelemetry_0_19_pkg as opentelemetry;
 #[cfg(feature = "opentelemetry_0_20")]
 use opentelemetry_0_20_pkg as opentelemetry;
+#[cfg(feature = "opentelemetry_0_21")]
+use opentelemetry_0_21_pkg as opentelemetry;
 
 #[cfg(feature = "opentelemetry_0_13")]
 use tracing_opentelemetry_0_12_pkg as tracing_opentelemetry;
@@ -33,6 +35,8 @@ use tracing_opentelemetry_0_18_pkg as tracing_opentelemetry;
 use tracing_opentelemetry_0_19_pkg as tracing_opentelemetry;
 #[cfg(feature = "opentelemetry_0_20")]
 use tracing_opentelemetry_0_21_pkg as tracing_opentelemetry;
+#[cfg(feature = "opentelemetry_0_21")]
+use tracing_opentelemetry_0_22_pkg as tracing_opentelemetry;
 
 use opentelemetry::propagation::Extractor;
 
@@ -70,7 +74,8 @@ pub(crate) fn set_otel_parent(req: &ServiceRequest, span: &tracing::Span) {
         feature = "opentelemetry_0_17",
         feature = "opentelemetry_0_18",
         feature = "opentelemetry_0_19",
-        feature = "opentelemetry_0_20"
+        feature = "opentelemetry_0_20",
+        feature = "opentelemetry_0_21"
     )))]
     let trace_id = span.context().span().span_context().trace_id().to_hex();
 
@@ -78,7 +83,8 @@ pub(crate) fn set_otel_parent(req: &ServiceRequest, span: &tracing::Span) {
         feature = "opentelemetry_0_17",
         feature = "opentelemetry_0_18",
         feature = "opentelemetry_0_19",
-        feature = "opentelemetry_0_20"
+        feature = "opentelemetry_0_20",
+        feature = "opentelemetry_0_21"
     ))]
     let trace_id = {
         let id = span.context().span().span_context().trace_id();

--- a/src/otel.rs
+++ b/src/otel.rs
@@ -75,7 +75,7 @@ pub(crate) fn set_otel_parent(req: &ServiceRequest, span: &tracing::Span) {
         feature = "opentelemetry_0_18",
         feature = "opentelemetry_0_19",
         feature = "opentelemetry_0_20",
-        feature = "opentelemetry_0_21"
+        feature = "opentelemetry_0_21",
     )))]
     let trace_id = span.context().span().span_context().trace_id().to_hex();
 
@@ -84,7 +84,7 @@ pub(crate) fn set_otel_parent(req: &ServiceRequest, span: &tracing::Span) {
         feature = "opentelemetry_0_18",
         feature = "opentelemetry_0_19",
         feature = "opentelemetry_0_20",
-        feature = "opentelemetry_0_21"
+        feature = "opentelemetry_0_21",
     ))]
     let trace_id = {
         let id = span.context().span().span_context().trace_id();

--- a/src/root_span_macro.rs
+++ b/src/root_span_macro.rs
@@ -164,7 +164,7 @@ pub mod private {
             feature = "opentelemetry_0_18",
             feature = "opentelemetry_0_19",
             feature = "opentelemetry_0_20",
-            feature = "opentelemetry_0_21"
+            feature = "opentelemetry_0_21",
         ))]
         crate::otel::set_otel_parent(req, span);
     }

--- a/src/root_span_macro.rs
+++ b/src/root_span_macro.rs
@@ -163,7 +163,8 @@ pub mod private {
             feature = "opentelemetry_0_17",
             feature = "opentelemetry_0_18",
             feature = "opentelemetry_0_19",
-            feature = "opentelemetry_0_20"
+            feature = "opentelemetry_0_20",
+            feature = "opentelemetry_0_21"
         ))]
         crate::otel::set_otel_parent(req, span);
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds support for OpenTelemetry 0.21. Nothing particularly interesting. While here, getting rid of the Fibonacci-exploding number of compile guards and use a single const-evaluated expression.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
