### PR TITLE
Support otel 0.22

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -56,6 +56,8 @@ jobs:
           - opentelemetry_0_18
           - opentelemetry_0_19
           - opentelemetry_0_20
+          - opentelemetry_0_21
+          - opentelemetry_0_22
     steps:
       - uses: actions/checkout@v2
       - name: Cache dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ opentelemetry_0_18 = ["opentelemetry_0_18_pkg", "tracing-opentelemetry_0_18_pkg"
 opentelemetry_0_19 = ["opentelemetry_0_19_pkg", "tracing-opentelemetry_0_19_pkg"]
 opentelemetry_0_20 = ["opentelemetry_0_20_pkg", "tracing-opentelemetry_0_21_pkg"]
 opentelemetry_0_21 = ["opentelemetry_0_21_pkg", "tracing-opentelemetry_0_22_pkg"]
+opentelemetry_0_22 = ["opentelemetry_0_22_pkg", "tracing-opentelemetry_0_23_pkg"]
 emit_event_on_error = []
 uuid_v7 = ["uuid/v7"]
 
@@ -47,15 +48,17 @@ opentelemetry_0_18_pkg = { package = "opentelemetry", version = "0.18", optional
 opentelemetry_0_19_pkg = { package = "opentelemetry", version = "0.19", optional = true }
 opentelemetry_0_20_pkg = { package = "opentelemetry", version = "0.20", optional = true }
 opentelemetry_0_21_pkg = { package = "opentelemetry", version = "0.21", optional = true }
-tracing-opentelemetry_0_12_pkg = { package = "tracing-opentelemetry",version = "0.12", optional = true }
+opentelemetry_0_22_pkg = { package = "opentelemetry", version = "0.22", optional = true }
+tracing-opentelemetry_0_12_pkg = { package = "tracing-opentelemetry", version = "0.12", optional = true }
 tracing-opentelemetry_0_13_pkg = { package = "tracing-opentelemetry", version = "0.13", optional = true }
-tracing-opentelemetry_0_14_pkg = { package = "tracing-opentelemetry",version = "0.14", optional = true }
-tracing-opentelemetry_0_16_pkg = { package = "tracing-opentelemetry",version = "0.16", optional = true }
-tracing-opentelemetry_0_17_pkg = { package = "tracing-opentelemetry",version = "0.17", optional = true }
-tracing-opentelemetry_0_18_pkg = { package = "tracing-opentelemetry",version = "0.18", optional = true }
-tracing-opentelemetry_0_19_pkg = { package = "tracing-opentelemetry",version = "0.19", optional = true }
-tracing-opentelemetry_0_21_pkg = { package = "tracing-opentelemetry",version = "0.21", optional = true }
-tracing-opentelemetry_0_22_pkg = { package = "tracing-opentelemetry",version = "0.22", optional = true }
+tracing-opentelemetry_0_14_pkg = { package = "tracing-opentelemetry", version = "0.14", optional = true }
+tracing-opentelemetry_0_16_pkg = { package = "tracing-opentelemetry", version = "0.16", optional = true }
+tracing-opentelemetry_0_17_pkg = { package = "tracing-opentelemetry", version = "0.17", optional = true }
+tracing-opentelemetry_0_18_pkg = { package = "tracing-opentelemetry", version = "0.18", optional = true }
+tracing-opentelemetry_0_19_pkg = { package = "tracing-opentelemetry", version = "0.19", optional = true }
+tracing-opentelemetry_0_21_pkg = { package = "tracing-opentelemetry", version = "0.21", optional = true }
+tracing-opentelemetry_0_22_pkg = { package = "tracing-opentelemetry", version = "0.22", optional = true }
+tracing-opentelemetry_0_23_pkg = { package = "tracing-opentelemetry", version = "0.23", optional = true }
 
 [dev-dependencies]
 actix-web = { version = "4", default-features = false, features = ["macros"] }

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ actix-web = "4"
 - `opentelemetry_0_19`: same as above but using `opentelemetry` 0.19;
 - `opentelemetry_0_20`: same as above but using `opentelemetry` 0.20;
 - `opentelemetry_0_21`: same as above but using `opentelemetry` 0.21;
+- `opentelemetry_0_22`: same as above but using `opentelemetry` 0.22;
 - `emit_event_on_error`: emit a [`tracing`] event when request processing fails with an error (enabled by default).
 - `uuid_v7`: use the UUID v7 implementation inside [`RequestId`] instead of UUID v4 (disabled by default).
 ## Quickstart

--- a/examples/custom-root-span/Cargo.toml
+++ b/examples/custom-root-span/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 actix-web = "4"
-opentelemetry = { version = "0.22", features = ["rt-tokio-current-thread"] }
+opentelemetry = "0.22"
 opentelemetry-jaeger = { version = "0.21", features = ["rt-tokio-current-thread"] }
 tracing-opentelemetry = { version = "0.23" }
 tracing = "0.1.19"

--- a/examples/custom-root-span/Cargo.toml
+++ b/examples/custom-root-span/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2018"
 
 [dependencies]
 actix-web = "4"
-opentelemetry = { version = "0.19", features = ["rt-tokio-current-thread"] }
-opentelemetry-jaeger = { version = "0.18", features = ["rt-tokio-current-thread"] }
-tracing-opentelemetry = { version = "0.19" }
+opentelemetry = { version = "0.22", features = ["rt-tokio-current-thread"] }
+opentelemetry-jaeger = { version = "0.21", features = ["rt-tokio-current-thread"] }
+tracing-opentelemetry = { version = "0.23" }
 tracing = "0.1.19"
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
 tracing-bunyan-formatter = "0.3"

--- a/examples/opentelemetry/Cargo.toml
+++ b/examples/opentelemetry/Cargo.toml
@@ -9,9 +9,9 @@ license = "MIT/Apache-2.0"
 [dependencies]
 actix-web = "4"
 tracing = "0.1.19"
-opentelemetry = { version = "0.19", features = ["rt-tokio-current-thread"] }
-opentelemetry-jaeger = { version = "0.18", features = ["rt-tokio-current-thread"] }
-tracing-opentelemetry = { version = "0.19" }
+opentelemetry = { version = "0.22", features = ["rt-tokio-current-thread"] }
+opentelemetry-jaeger = { version = "0.21", features = ["rt-tokio-current-thread"] }
+tracing-opentelemetry = { version = "0.23" }
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
 tracing-bunyan-formatter = "0.3"
 tracing-actix-web = { path = "../..", features = ["opentelemetry_0_19"] }

--- a/examples/opentelemetry/Cargo.toml
+++ b/examples/opentelemetry/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 [dependencies]
 actix-web = "4"
 tracing = "0.1.19"
-opentelemetry = { version = "0.22", features = ["rt-tokio-current-thread"] }
+opentelemetry = "0.22"
 opentelemetry-jaeger = { version = "0.21", features = ["rt-tokio-current-thread"] }
 tracing-opentelemetry = { version = "0.23" }
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }

--- a/examples/opentelemetry/Cargo.toml
+++ b/examples/opentelemetry/Cargo.toml
@@ -14,4 +14,4 @@ opentelemetry-jaeger = { version = "0.21", features = ["rt-tokio-current-thread"
 tracing-opentelemetry = { version = "0.23" }
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
 tracing-bunyan-formatter = "0.3"
-tracing-actix-web = { path = "../..", features = ["opentelemetry_0_19"] }
+tracing-actix-web = { path = "../..", features = ["opentelemetry_0_22"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@
 //! - `opentelemetry_0_19`: same as above but using `opentelemetry` 0.19;
 //! - `opentelemetry_0_20`: same as above but using `opentelemetry` 0.20;
 //! - `opentelemetry_0_21`: same as above but using `opentelemetry` 0.21;
+//! - `opentelemetry_0_22`: same as above but using `opentelemetry` 0.22;
 //! - `emit_event_on_error`: emit a [`tracing`] event when request processing fails with an error (enabled by default).
 //! - `uuid_v7`: use the UUID v7 implementation inside [`RequestId`] instead of UUID v4 (disabled by default).
 //!
@@ -46,7 +47,7 @@
 //! ```
 //!
 //! Check out [the examples on GitHub](https://github.com/LukeMathWalker/tracing-actix-web/tree/main/examples) to get a taste of how [`TracingLogger`] can be used to observe and monitor your
-//! application.  
+//! application.
 //!
 //! # From zero to hero: a crash course in observability
 //!
@@ -55,27 +56,27 @@
 //! [`TracingLogger`] is built on top of [`tracing`], a modern instrumentation framework with
 //! [a vibrant ecosystem](https://github.com/tokio-rs/tracing#related-crates).
 //!
-//! `tracing-actix-web`'s documentation provides a crash course in how to use [`tracing`] to instrument an `actix-web` application.  
+//! `tracing-actix-web`'s documentation provides a crash course in how to use [`tracing`] to instrument an `actix-web` application.
 //! If you want to learn more check out ["Are we observable yet?"](https://www.lpalmieri.com/posts/2020-09-27-zero-to-production-4-are-we-observable-yet/) -
 //! it provides an in-depth introduction to the crate and the problems it solves within the bigger picture of [observability](https://docs.honeycomb.io/learning-about-observability/).
 //!
 //! ## The root span
 //!
-//! [`tracing::Span`] is the key abstraction in [`tracing`]: it represents a unit of work in your system.  
+//! [`tracing::Span`] is the key abstraction in [`tracing`]: it represents a unit of work in your system.
 //! A [`tracing::Span`] has a beginning and an end. It can include one or more **child spans** to represent sub-unit
 //! of works within a larger task.
 //!
-//! When your application receives a request, [`TracingLogger`] creates a new span - we call it the **[root span]**.  
+//! When your application receives a request, [`TracingLogger`] creates a new span - we call it the **[root span]**.
 //! All the spans created _while_ processing the request will be children of the root span.
 //!
-//! [`tracing`] empowers us to attach structured properties to a span as a collection of key-value pairs.  
+//! [`tracing`] empowers us to attach structured properties to a span as a collection of key-value pairs.
 //! Those properties can then be queried in a variety of tools (e.g. ElasticSearch, Honeycomb, DataDog) to
-//! understand what is happening in your system.  
+//! understand what is happening in your system.
 //!
 //! ## Customisation via [`RootSpanBuilder`]
 //!
 //! Troubleshooting becomes much easier when the root span has a _rich context_ - e.g. you can understand most of what
-//! happened when processing the request just by looking at the properties attached to the corresponding root span.  
+//! happened when processing the request just by looking at the properties attached to the corresponding root span.
 //!
 //! You might have heard of this technique as the [canonical log line pattern](https://stripe.com/blog/canonical-log-lines),
 //! popularised by Stripe. It is more recently discussed in terms of [high-cardinality events](https://www.honeycomb.io/blog/observability-a-manifesto/)
@@ -94,11 +95,11 @@
 //! let another_way = TracingLogger::<DefaultRootSpanBuilder>::new();
 //! ```
 //!
-//! We are delegating the construction of the root span to [`DefaultRootSpanBuilder`].  
+//! We are delegating the construction of the root span to [`DefaultRootSpanBuilder`].
 //! [`DefaultRootSpanBuilder`] captures, out of the box, several dimensions that are usually relevant when looking at an HTTP
 //! API: method, version, route, etc. - check out its documentation for an extensive list.
 //!
-//! You can customise the root span by providing your own implementation of the [`RootSpanBuilder`] trait.  
+//! You can customise the root span by providing your own implementation of the [`RootSpanBuilder`] trait.
 //! Let's imagine, for example, that our system cares about a client identifier embedded inside an authorization header.
 //! We could add a `client_id` property to the root span using a custom builder, `DomainRootSpanBuilder`:
 //!
@@ -123,9 +124,9 @@
 //! let custom_middleware = TracingLogger::<DomainRootSpanBuilder>::new();
 //! ```
 //!
-//! There is an issue, though: `client_id` is the _only_ property we are capturing.  
+//! There is an issue, though: `client_id` is the _only_ property we are capturing.
 //! With `DomainRootSpanBuilder`, as it is, we do not get any of that useful HTTP-related information provided by
-//! [`DefaultRootSpanBuilder`].  
+//! [`DefaultRootSpanBuilder`].
 //!
 //! We can do better!
 //!
@@ -153,9 +154,9 @@
 //! ```
 //!
 //! [`root_span!`] is a macro provided by `tracing-actix-web`: it creates a new span by combining all the HTTP properties tracked
-//! by [`DefaultRootSpanBuilder`] with the custom ones you specify when calling it (e.g. `client_id` in our example).  
+//! by [`DefaultRootSpanBuilder`] with the custom ones you specify when calling it (e.g. `client_id` in our example).
 //!
-//! We need to use a macro because `tracing` requires all the properties attached to a span to be declared upfront, when the span is created.  
+//! We need to use a macro because `tracing` requires all the properties attached to a span to be declared upfront, when the span is created.
 //! You cannot add new ones afterwards. This makes it extremely fast, but it pushes us to reach for macros when we need some level of
 //! composition.
 //!
@@ -191,7 +192,7 @@
 //!
 //! ## The [`RootSpan`] extractor
 //!
-//! It often happens that not all information about a task is known upfront, encoded in the incoming request.  
+//! It often happens that not all information about a task is known upfront, encoded in the incoming request.
 //! You can use the [`RootSpan`] extractor to grab the root span in your handlers and attach more information
 //! to your root span as it becomes available:
 //!
@@ -265,10 +266,10 @@
 //! To fulfill a request you often have to perform additional I/O operations - e.g. calls to other REST or gRPC APIs, database queries, etc.
 //! **Distributed tracing** is the standard approach to **trace** a single request across the entirety of your stack.
 //!
-//! `tracing-actix-web` provides support for distributed tracing by supporting the [OpenTelemetry standard](https://opentelemetry.io/).  
+//! `tracing-actix-web` provides support for distributed tracing by supporting the [OpenTelemetry standard](https://opentelemetry.io/).
 //! `tracing-actix-web` follows [OpenTelemetry's semantic convention](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#spancontext)
 //! for field names.
-//! Furthermore, it provides an `opentelemetry_0_17` feature flag to automatically performs trace propagation: it tries to extract the OpenTelemetry context out of the headers of incoming requests and, when it finds one, it sets it as the remote context for the current root span. The context is then propagated to your downstream dependencies if your HTTP or gRPC clients are OpenTelemetry-aware - e.g. using [`reqwest-middleware` and `reqwest-tracing`](https://github.com/TrueLayer/reqwest-middleware) if you are using `reqwest` as your HTTP client.  
+//! Furthermore, it provides an `opentelemetry_0_17` feature flag to automatically performs trace propagation: it tries to extract the OpenTelemetry context out of the headers of incoming requests and, when it finds one, it sets it as the remote context for the current root span. The context is then propagated to your downstream dependencies if your HTTP or gRPC clients are OpenTelemetry-aware - e.g. using [`reqwest-middleware` and `reqwest-tracing`](https://github.com/TrueLayer/reqwest-middleware) if you are using `reqwest` as your HTTP client.
 //! You can then find all logs for the same request across all the services it touched by looking for the `trace_id`, automatically logged by `tracing-actix-web`.
 //!
 //! If you add [`tracing-opentelemetry::OpenTelemetryLayer`](https://docs.rs/tracing-opentelemetry/0.17.0/tracing_opentelemetry/struct.OpenTelemetryLayer.html)
@@ -303,6 +304,7 @@ mutually_exclusive_features::none_or_one_of!(
     "opentelemetry_0_19",
     "opentelemetry_0_20",
     "opentelemetry_0_21",
+    "opentelemetry_0_22",
 );
 
 #[cfg(any(
@@ -315,5 +317,6 @@ mutually_exclusive_features::none_or_one_of!(
     feature = "opentelemetry_0_19",
     feature = "opentelemetry_0_20",
     feature = "opentelemetry_0_21",
+    feature = "opentelemetry_0_22",
 ))]
 mod otel;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,20 +56,20 @@
 //! [`TracingLogger`] is built on top of [`tracing`], a modern instrumentation framework with
 //! [a vibrant ecosystem](https://github.com/tokio-rs/tracing#related-crates).
 //!
-//! `tracing-actix-web`'s documentation provides a crash course in how to use [`tracing`] to instrument an `actix-web` application.
+//! `tracing-actix-web`'s documentation provides a crash course in how to use [`tracing`] to instrument an `actix-web` application.  
 //! If you want to learn more check out ["Are we observable yet?"](https://www.lpalmieri.com/posts/2020-09-27-zero-to-production-4-are-we-observable-yet/) -
 //! it provides an in-depth introduction to the crate and the problems it solves within the bigger picture of [observability](https://docs.honeycomb.io/learning-about-observability/).
 //!
 //! ## The root span
 //!
-//! [`tracing::Span`] is the key abstraction in [`tracing`]: it represents a unit of work in your system.
+//! [`tracing::Span`] is the key abstraction in [`tracing`]: it represents a unit of work in your system.  
 //! A [`tracing::Span`] has a beginning and an end. It can include one or more **child spans** to represent sub-unit
 //! of works within a larger task.
 //!
-//! When your application receives a request, [`TracingLogger`] creates a new span - we call it the **[root span]**.
+//! When your application receives a request, [`TracingLogger`] creates a new span - we call it the **[root span]**.  
 //! All the spans created _while_ processing the request will be children of the root span.
 //!
-//! [`tracing`] empowers us to attach structured properties to a span as a collection of key-value pairs.
+//! [`tracing`] empowers us to attach structured properties to a span as a collection of key-value pairs.  
 //! Those properties can then be queried in a variety of tools (e.g. ElasticSearch, Honeycomb, DataDog) to
 //! understand what is happening in your system.
 //!
@@ -95,11 +95,11 @@
 //! let another_way = TracingLogger::<DefaultRootSpanBuilder>::new();
 //! ```
 //!
-//! We are delegating the construction of the root span to [`DefaultRootSpanBuilder`].
+//! We are delegating the construction of the root span to [`DefaultRootSpanBuilder`].  
 //! [`DefaultRootSpanBuilder`] captures, out of the box, several dimensions that are usually relevant when looking at an HTTP
 //! API: method, version, route, etc. - check out its documentation for an extensive list.
 //!
-//! You can customise the root span by providing your own implementation of the [`RootSpanBuilder`] trait.
+//! You can customise the root span by providing your own implementation of the [`RootSpanBuilder`] trait.  
 //! Let's imagine, for example, that our system cares about a client identifier embedded inside an authorization header.
 //! We could add a `client_id` property to the root span using a custom builder, `DomainRootSpanBuilder`:
 //!
@@ -124,7 +124,7 @@
 //! let custom_middleware = TracingLogger::<DomainRootSpanBuilder>::new();
 //! ```
 //!
-//! There is an issue, though: `client_id` is the _only_ property we are capturing.
+//! There is an issue, though: `client_id` is the _only_ property we are capturing.  
 //! With `DomainRootSpanBuilder`, as it is, we do not get any of that useful HTTP-related information provided by
 //! [`DefaultRootSpanBuilder`].
 //!
@@ -156,7 +156,7 @@
 //! [`root_span!`] is a macro provided by `tracing-actix-web`: it creates a new span by combining all the HTTP properties tracked
 //! by [`DefaultRootSpanBuilder`] with the custom ones you specify when calling it (e.g. `client_id` in our example).
 //!
-//! We need to use a macro because `tracing` requires all the properties attached to a span to be declared upfront, when the span is created.
+//! We need to use a macro because `tracing` requires all the properties attached to a span to be declared upfront, when the span is created.  
 //! You cannot add new ones afterwards. This makes it extremely fast, but it pushes us to reach for macros when we need some level of
 //! composition.
 //!
@@ -192,7 +192,7 @@
 //!
 //! ## The [`RootSpan`] extractor
 //!
-//! It often happens that not all information about a task is known upfront, encoded in the incoming request.
+//! It often happens that not all information about a task is known upfront, encoded in the incoming request.  
 //! You can use the [`RootSpan`] extractor to grab the root span in your handlers and attach more information
 //! to your root span as it becomes available:
 //!
@@ -266,10 +266,10 @@
 //! To fulfill a request you often have to perform additional I/O operations - e.g. calls to other REST or gRPC APIs, database queries, etc.
 //! **Distributed tracing** is the standard approach to **trace** a single request across the entirety of your stack.
 //!
-//! `tracing-actix-web` provides support for distributed tracing by supporting the [OpenTelemetry standard](https://opentelemetry.io/).
+//! `tracing-actix-web` provides support for distributed tracing by supporting the [OpenTelemetry standard](https://opentelemetry.io/).  
 //! `tracing-actix-web` follows [OpenTelemetry's semantic convention](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#spancontext)
 //! for field names.
-//! Furthermore, it provides an `opentelemetry_0_17` feature flag to automatically performs trace propagation: it tries to extract the OpenTelemetry context out of the headers of incoming requests and, when it finds one, it sets it as the remote context for the current root span. The context is then propagated to your downstream dependencies if your HTTP or gRPC clients are OpenTelemetry-aware - e.g. using [`reqwest-middleware` and `reqwest-tracing`](https://github.com/TrueLayer/reqwest-middleware) if you are using `reqwest` as your HTTP client.
+//! Furthermore, it provides an `opentelemetry_0_17` feature flag to automatically performs trace propagation: it tries to extract the OpenTelemetry context out of the headers of incoming requests and, when it finds one, it sets it as the remote context for the current root span. The context is then propagated to your downstream dependencies if your HTTP or gRPC clients are OpenTelemetry-aware - e.g. using [`reqwest-middleware` and `reqwest-tracing`](https://github.com/TrueLayer/reqwest-middleware) if you are using `reqwest` as your HTTP client.  
 //! You can then find all logs for the same request across all the services it touched by looking for the `trace_id`, automatically logged by `tracing-actix-web`.
 //!
 //! If you add [`tracing-opentelemetry::OpenTelemetryLayer`](https://docs.rs/tracing-opentelemetry/0.17.0/tracing_opentelemetry/struct.OpenTelemetryLayer.html)

--- a/src/otel.rs
+++ b/src/otel.rs
@@ -18,6 +18,8 @@ use opentelemetry_0_19_pkg as opentelemetry;
 use opentelemetry_0_20_pkg as opentelemetry;
 #[cfg(feature = "opentelemetry_0_21")]
 use opentelemetry_0_21_pkg as opentelemetry;
+#[cfg(feature = "opentelemetry_0_22")]
+use opentelemetry_0_22_pkg as opentelemetry;
 
 #[cfg(feature = "opentelemetry_0_13")]
 use tracing_opentelemetry_0_12_pkg as tracing_opentelemetry;
@@ -37,6 +39,8 @@ use tracing_opentelemetry_0_19_pkg as tracing_opentelemetry;
 use tracing_opentelemetry_0_21_pkg as tracing_opentelemetry;
 #[cfg(feature = "opentelemetry_0_21")]
 use tracing_opentelemetry_0_22_pkg as tracing_opentelemetry;
+#[cfg(feature = "opentelemetry_0_22")]
+use tracing_opentelemetry_0_23_pkg as tracing_opentelemetry;
 
 use opentelemetry::propagation::Extractor;
 
@@ -76,6 +80,7 @@ pub(crate) fn set_otel_parent(req: &ServiceRequest, span: &tracing::Span) {
         feature = "opentelemetry_0_19",
         feature = "opentelemetry_0_20",
         feature = "opentelemetry_0_21",
+        feature = "opentelemetry_0_22",
     )))]
     let trace_id = span.context().span().span_context().trace_id().to_hex();
 
@@ -85,6 +90,7 @@ pub(crate) fn set_otel_parent(req: &ServiceRequest, span: &tracing::Span) {
         feature = "opentelemetry_0_19",
         feature = "opentelemetry_0_20",
         feature = "opentelemetry_0_21",
+        feature = "opentelemetry_0_22",
     ))]
     let trace_id = {
         let id = span.context().span().span_context().trace_id();

--- a/src/root_span_macro.rs
+++ b/src/root_span_macro.rs
@@ -165,6 +165,7 @@ pub mod private {
             feature = "opentelemetry_0_19",
             feature = "opentelemetry_0_20",
             feature = "opentelemetry_0_21",
+            feature = "opentelemetry_0_22",
         ))]
         crate::otel::set_otel_parent(req, span);
     }


### PR DESCRIPTION
Support Open Telemetry 0.22

It's a draft, waiting for the `tracing-opentelemetry 0.23` to be available.