### PR TITLE
Remove `--cfg uuid_unstable` requirement for `uuid_v7` feature

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -80,9 +80,6 @@ jobs:
   test_uuid_v7:
     name: Test
     runs-on: ubuntu-latest
-    env:
-      RUSTFLAGS: "--cfg uuid_unstable"
-      RUSTDOCFLAGS: "--cfg uuid_unstable"
     steps:
       - uses: actions/checkout@v2
       - name: Cache dependencies

--- a/README.md
+++ b/README.md
@@ -289,8 +289,6 @@ If you need to **trace** a request across multiple services (e.g. in a microserv
 
 Optionally, using the `uuid_v7` feature flag will allow [`RequestId`] to use UUID v7 instead of the currently used UUID v4.
 
-However, the [`uuid`] crate requires a compile time flag `uuid_unstable` to be passed in `RUSTFLAGS="--cfg uuid_unstable"` in order to compile. You can read more about it [here](https://docs.rs/uuid/latest/uuid/#unstable-features).
-
 ## Trace Id
 
 To fulfill a request you often have to perform additional I/O operations - e.g. calls to other REST or gRPC APIs, database queries, etc.  

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,8 +258,6 @@
 //!
 //! Optionally, using the `uuid_v7` feature flag will allow [`RequestId`] to use UUID v7 instead of the currently used UUID v4.
 //!
-//! However, the [`uuid`] crate requires a compile time flag `uuid_unstable` to be passed in `RUSTFLAGS="--cfg uuid_unstable"` in order to compile. You can read more about it [here](https://docs.rs/uuid/latest/uuid/#unstable-features).
-//!
 //! ## Trace Id
 //!
 //! To fulfill a request you often have to perform additional I/O operations - e.g. calls to other REST or gRPC APIs, database queries, etc.

--- a/src/request_id.rs
+++ b/src/request_id.rs
@@ -27,23 +27,16 @@ use uuid::Uuid;
 /// ```
 ///
 /// Optionally, using the `uuid_v7` feature flag will allow [`RequestId`] to use UUID v7 instead of the currently used UUID v4.
-///
-/// However, the [`uuid`] crate requires a compile time flag `uuid_unstable` to be passed in `RUSTFLAGS="--cfg uuid_unstable"` in order to compile. You can read more about it [here](https://docs.rs/uuid/latest/uuid/#unstable-features).
-///
 #[derive(Clone, Copy, Debug)]
 pub struct RequestId(Uuid);
 
 impl RequestId {
     pub(crate) fn generate() -> Self {
-        // Compiler error for providing context on requirements to enable the `uuid_v7` feature flag
-        #[cfg(all(feature = "uuid_v7", not(uuid_unstable)))]
-        compile_error!("feature \"uuid_v7\" requires \"uuid_unstable\" to be passed as configuration in rustflags");
-
         #[cfg(not(feature = "uuid_v7"))]
         {
             Self(Uuid::new_v4())
         }
-        #[cfg(all(uuid_unstable, feature = "uuid_v7"))]
+        #[cfg(feature = "uuid_v7")]
         {
             Self(Uuid::now_v7())
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR removes the requirement that `RUSTFLAGS="--cfg uuid_unstable"` be provided to use the `uuid_v7` feature flag, and thus the `v7` feature flag from the `uuid` crate.

The `uuid` crate stabilized support for UUID v6-v8 in uuid-rs/uuid#718, which was included in the `1.6.0` release of the `uuid` crate. Since `tracing-actix-web` pulls the `uuid` crate using only the major version (`1`) and does not include the minor version, I believe it is safe to remove the `--cfg uuid_unstable` requirement.

Essentially, I just went through the changes done in #116 and removed some lines which were no longer applicable.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
