### PR TITLE
Support otel 0.23

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -58,6 +58,7 @@ jobs:
           - opentelemetry_0_20
           - opentelemetry_0_21
           - opentelemetry_0_22
+          - opentelemetry_0_23
     steps:
       - uses: actions/checkout@v2
       - name: Cache dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ opentelemetry_0_19 = ["opentelemetry_0_19_pkg", "tracing-opentelemetry_0_19_pkg"
 opentelemetry_0_20 = ["opentelemetry_0_20_pkg", "tracing-opentelemetry_0_21_pkg"]
 opentelemetry_0_21 = ["opentelemetry_0_21_pkg", "tracing-opentelemetry_0_22_pkg"]
 opentelemetry_0_22 = ["opentelemetry_0_22_pkg", "tracing-opentelemetry_0_23_pkg"]
+opentelemetry_0_23 = ["opentelemetry_0_23_pkg", "tracing-opentelemetry_0_24_pkg"]
 emit_event_on_error = []
 uuid_v7 = ["uuid/v7"]
 
@@ -49,6 +50,7 @@ opentelemetry_0_19_pkg = { package = "opentelemetry", version = "0.19", optional
 opentelemetry_0_20_pkg = { package = "opentelemetry", version = "0.20", optional = true }
 opentelemetry_0_21_pkg = { package = "opentelemetry", version = "0.21", optional = true }
 opentelemetry_0_22_pkg = { package = "opentelemetry", version = "0.22", optional = true }
+opentelemetry_0_23_pkg = { package = "opentelemetry", version = "0.23", optional = true }
 tracing-opentelemetry_0_12_pkg = { package = "tracing-opentelemetry", version = "0.12", optional = true }
 tracing-opentelemetry_0_13_pkg = { package = "tracing-opentelemetry", version = "0.13", optional = true }
 tracing-opentelemetry_0_14_pkg = { package = "tracing-opentelemetry", version = "0.14", optional = true }
@@ -59,6 +61,7 @@ tracing-opentelemetry_0_19_pkg = { package = "tracing-opentelemetry", version = 
 tracing-opentelemetry_0_21_pkg = { package = "tracing-opentelemetry", version = "0.21", optional = true }
 tracing-opentelemetry_0_22_pkg = { package = "tracing-opentelemetry", version = "0.22", optional = true }
 tracing-opentelemetry_0_23_pkg = { package = "tracing-opentelemetry", version = "0.23", optional = true }
+tracing-opentelemetry_0_24_pkg = { package = "tracing-opentelemetry", version = "0.24", optional = true }
 
 [dev-dependencies]
 actix-web = { version = "4", default-features = false, features = ["macros"] }

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ actix-web = "4"
 - `opentelemetry_0_20`: same as above but using `opentelemetry` 0.20;
 - `opentelemetry_0_21`: same as above but using `opentelemetry` 0.21;
 - `opentelemetry_0_22`: same as above but using `opentelemetry` 0.22;
+- `opentelemetry_0_23`: same as above but using `opentelemetry` 0.23;
 - `emit_event_on_error`: emit a [`tracing`] event when request processing fails with an error (enabled by default).
 - `uuid_v7`: use the UUID v7 implementation inside [`RequestId`] instead of UUID v4 (disabled by default).
 ## Quickstart

--- a/examples/opentelemetry/Cargo.toml
+++ b/examples/opentelemetry/Cargo.toml
@@ -9,9 +9,9 @@ license = "MIT/Apache-2.0"
 [dependencies]
 actix-web = "4"
 tracing = "0.1.19"
-opentelemetry = "0.22"
-opentelemetry-jaeger = { version = "0.21", features = ["rt-tokio-current-thread"] }
-tracing-opentelemetry = { version = "0.23" }
+opentelemetry = "0.23"
+opentelemetry-jaeger = { version = "0.22", features = ["rt-tokio-current-thread"] }
+tracing-opentelemetry = { version = "0.24" }
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }
 tracing-bunyan-formatter = "0.3"
-tracing-actix-web = { path = "../..", features = ["opentelemetry_0_22"] }
+tracing-actix-web = { path = "../..", features = ["opentelemetry_0_23"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@
 //! - `opentelemetry_0_20`: same as above but using `opentelemetry` 0.20;
 //! - `opentelemetry_0_21`: same as above but using `opentelemetry` 0.21;
 //! - `opentelemetry_0_22`: same as above but using `opentelemetry` 0.22;
+//! - `opentelemetry_0_23`: same as above but using `opentelemetry` 0.23;
 //! - `emit_event_on_error`: emit a [`tracing`] event when request processing fails with an error (enabled by default).
 //! - `uuid_v7`: use the UUID v7 implementation inside [`RequestId`] instead of UUID v4 (disabled by default).
 //!
@@ -303,6 +304,7 @@ mutually_exclusive_features::none_or_one_of!(
     "opentelemetry_0_20",
     "opentelemetry_0_21",
     "opentelemetry_0_22",
+    "opentelemetry_0_23",
 );
 
 #[cfg(any(
@@ -316,5 +318,6 @@ mutually_exclusive_features::none_or_one_of!(
     feature = "opentelemetry_0_20",
     feature = "opentelemetry_0_21",
     feature = "opentelemetry_0_22",
+    feature = "opentelemetry_0_23",
 ))]
 mod otel;

--- a/src/otel.rs
+++ b/src/otel.rs
@@ -20,6 +20,8 @@ use opentelemetry_0_20_pkg as opentelemetry;
 use opentelemetry_0_21_pkg as opentelemetry;
 #[cfg(feature = "opentelemetry_0_22")]
 use opentelemetry_0_22_pkg as opentelemetry;
+#[cfg(feature = "opentelemetry_0_23")]
+use opentelemetry_0_23_pkg as opentelemetry;
 
 #[cfg(feature = "opentelemetry_0_13")]
 use tracing_opentelemetry_0_12_pkg as tracing_opentelemetry;
@@ -41,6 +43,8 @@ use tracing_opentelemetry_0_21_pkg as tracing_opentelemetry;
 use tracing_opentelemetry_0_22_pkg as tracing_opentelemetry;
 #[cfg(feature = "opentelemetry_0_22")]
 use tracing_opentelemetry_0_23_pkg as tracing_opentelemetry;
+#[cfg(feature = "opentelemetry_0_23")]
+use tracing_opentelemetry_0_24_pkg as tracing_opentelemetry;
 
 use opentelemetry::propagation::Extractor;
 
@@ -81,6 +85,7 @@ pub(crate) fn set_otel_parent(req: &ServiceRequest, span: &tracing::Span) {
         feature = "opentelemetry_0_20",
         feature = "opentelemetry_0_21",
         feature = "opentelemetry_0_22",
+        feature = "opentelemetry_0_23",
     )))]
     let trace_id = span.context().span().span_context().trace_id().to_hex();
 
@@ -91,6 +96,7 @@ pub(crate) fn set_otel_parent(req: &ServiceRequest, span: &tracing::Span) {
         feature = "opentelemetry_0_20",
         feature = "opentelemetry_0_21",
         feature = "opentelemetry_0_22",
+        feature = "opentelemetry_0_23",
     ))]
     let trace_id = {
         let id = span.context().span().span_context().trace_id();

--- a/src/root_span_macro.rs
+++ b/src/root_span_macro.rs
@@ -166,6 +166,7 @@ pub mod private {
             feature = "opentelemetry_0_20",
             feature = "opentelemetry_0_21",
             feature = "opentelemetry_0_22",
+            feature = "opentelemetry_0_23",
         ))]
         crate::otel::set_otel_parent(req, span);
     }


### PR DESCRIPTION
Support Open Telemetry 0.23

It's a draft, waiting for the `tracing-opentelemetry 0.24` to be available.
