### PR TITLE
fix: follow latest OTEL semantic conventions for the span name

### DIFF
--- a/src/root_span_macro.rs
+++ b/src/root_span_macro.rs
@@ -103,7 +103,7 @@ macro_rules! root_span {
                         http.user_agent = %user_agent,
                         http.target = %$request.uri().path_and_query().map(|p| p.as_str()).unwrap_or(""),
                         http.status_code = $crate::root_span_macro::private::tracing::field::Empty,
-                        otel.name = %format!("HTTP {} {}", http_method, http_route),
+                        otel.name = %format!("{} {}", http_method, http_route),
                         otel.kind = "server",
                         otel.status_code = $crate::root_span_macro::private::tracing::field::Empty,
                         trace_id = $crate::root_span_macro::private::tracing::field::Empty,


### PR DESCRIPTION
see: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#name

Hey,
I am not sure if the convention has changed recently or if this "HTTP" at the beginning of the name had a purpose, but this is breaking some compatibilities with other tools. Kindly let me know what you think please 😃 

Thank you!