### PR TITLE
feat: add `http.peer_ip` to the root span

### DIFF
--- a/src/root_span_macro.rs
+++ b/src/root_span_macro.rs
@@ -100,6 +100,7 @@ macro_rules! root_span {
                         http.scheme = %$crate::root_span_macro::private::http_scheme(connection_info.scheme()),
                         http.host = %connection_info.host(),
                         http.client_ip = %$request.connection_info().realip_remote_addr().unwrap_or(""),
+                        http.peer_ip = %$request.connection_info().peer_addr().unwrap_or(""),
                         http.user_agent = %user_agent,
                         http.target = %$request.uri().path_and_query().map(|p| p.as_str()).unwrap_or(""),
                         http.status_code = $crate::root_span_macro::private::tracing::field::Empty,


### PR DESCRIPTION
`realip_remote_addr` can be spoofed without using proxy or not configuring it properly. `peer_addr` is considered more trustworthy for security-sensitive operations, which is the actual socket address of the client when not behind any proxy, and the proxy's address otherwise.

When we are using a trusted and properly configured proxy, `peer_addr` should return the proxy's address, and `realip_remote_addr` should return a trusted client address.


Read:
    https://docs.rs/actix-web/4.11.0/actix_web/dev/struct.ConnectionInfo.html#security