### PR TITLE
Support Opentelemetry 0.31

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 
 [package]
 name = "tracing-actix-web"
-version = "0.7.19"
+version = "0.7.20"
 authors = ["Luca Palmieri <rust@lpalmieri.com>"]
 edition = "2018"
 
@@ -97,6 +97,10 @@ opentelemetry_0_30 = [
     "opentelemetry_0_30_pkg",
     "tracing-opentelemetry_0_31_pkg",
 ]
+opentelemetry_0_31 = [
+    "opentelemetry_0_31_pkg",
+    "tracing-opentelemetry_0_32_pkg",
+]
 emit_event_on_error = []
 uuid_v7 = ["uuid/v7"]
 
@@ -124,6 +128,7 @@ opentelemetry_0_27_pkg = { package = "opentelemetry", version = "0.27", optional
 opentelemetry_0_28_pkg = { package = "opentelemetry", version = "0.28", optional = true }
 opentelemetry_0_29_pkg = { package = "opentelemetry", version = "0.29", optional = true }
 opentelemetry_0_30_pkg = { package = "opentelemetry", version = "0.30", optional = true }
+opentelemetry_0_31_pkg = { package = "opentelemetry", version = "0.31", optional = true }
 tracing-opentelemetry_0_12_pkg = { package = "tracing-opentelemetry", version = "0.12", optional = true }
 tracing-opentelemetry_0_13_pkg = { package = "tracing-opentelemetry", version = "0.13", optional = true }
 tracing-opentelemetry_0_14_pkg = { package = "tracing-opentelemetry", version = "0.14", optional = true }
@@ -142,6 +147,7 @@ tracing-opentelemetry_0_28_pkg = { package = "tracing-opentelemetry", version = 
 tracing-opentelemetry_0_29_pkg = { package = "tracing-opentelemetry", version = "0.29", optional = true }
 tracing-opentelemetry_0_30_pkg = { package = "tracing-opentelemetry", version = "0.30", optional = true }
 tracing-opentelemetry_0_31_pkg = { package = "tracing-opentelemetry", version = "0.31", optional = true }
+tracing-opentelemetry_0_32_pkg = { package = "tracing-opentelemetry", version = "0.32", optional = true }
 
 [dev-dependencies]
 actix-web = { version = "4", default-features = false, features = ["macros"] }

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ actix-web = "4"
 - `opentelemetry_0_28`: same as above but using `opentelemetry` 0.28;
 - `opentelemetry_0_29`: same as above but using `opentelemetry` 0.29;
 - `opentelemetry_0_30`: same as above but using `opentelemetry` 0.30;
+- `opentelemetry_0_31`: same as above but using `opentelemetry` 0.31;
 - `emit_event_on_error`: emit a [`tracing`] event when request processing fails with an error (enabled by default).
 - `uuid_v7`: use the UUID v7 implementation inside [`RequestId`] instead of UUID v4 (disabled by default).
 ## Quickstart

--- a/examples/custom-root-span/Cargo.toml
+++ b/examples/custom-root-span/Cargo.toml
@@ -8,12 +8,12 @@ edition = "2021"
 
 [dependencies]
 actix-web = "4"
-opentelemetry = "0.30"
-opentelemetry-otlp = { version = "0.30", features = ["grpc-tonic"] }
-opentelemetry_sdk = { version = "0.30", features = ["rt-tokio-current-thread"] }
-opentelemetry-semantic-conventions = "0.30"
-tracing-opentelemetry = "0.31"
+opentelemetry = "0.31"
+opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic"] }
+opentelemetry_sdk = { version = "0.31", features = ["rt-tokio-current-thread"] }
+opentelemetry-semantic-conventions = "0.31"
+tracing-opentelemetry = "0.32"
 tracing = "0.1"
-tracing-actix-web = { path = "../..", features = ["opentelemetry_0_30"] }
+tracing-actix-web = { path = "../..", features = ["opentelemetry_0_31"] }
 tracing-bunyan-formatter = "0.3"
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }

--- a/examples/opentelemetry/Cargo.toml
+++ b/examples/opentelemetry/Cargo.toml
@@ -8,12 +8,12 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 actix-web = "4"
-opentelemetry = "0.30"
-opentelemetry-otlp = { version = "0.30", features = ["grpc-tonic"] }
-opentelemetry_sdk = { version = "0.30", features = ["rt-tokio-current-thread"] }
-opentelemetry-semantic-conventions = "0.30"
+opentelemetry = "0.31"
+opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic"] }
+opentelemetry_sdk = { version = "0.31", features = ["rt-tokio-current-thread"] }
+opentelemetry-semantic-conventions = "0.31"
 tracing = "0.1"
-tracing-actix-web = { path = "../..", features = ["opentelemetry_0_30"] }
+tracing-actix-web = { path = "../..", features = ["opentelemetry_0_31"] }
 tracing-bunyan-formatter = "0.3"
-tracing-opentelemetry = "0.31"
+tracing-opentelemetry = "0.32"
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@
 //! - `opentelemetry_0_28`: same as above but using `opentelemetry` 0.28;
 //! - `opentelemetry_0_29`: same as above but using `opentelemetry` 0.29;
 //! - `opentelemetry_0_30`: same as above but using `opentelemetry` 0.30;
+//! - `opentelemetry_0_31`: same as above but using `opentelemetry` 0.31;
 //! - `emit_event_on_error`: emit a [`tracing`] event when request processing fails with an error (enabled by default).
 //! - `uuid_v7`: use the UUID v7 implementation inside [`RequestId`] instead of UUID v4 (disabled by default).
 //!
@@ -319,6 +320,7 @@ mutually_exclusive_features::none_or_one_of!(
     "opentelemetry_0_28",
     "opentelemetry_0_29",
     "opentelemetry_0_30",
+    "opentelemetry_0_31",
 );
 
 #[cfg(any(
@@ -340,5 +342,6 @@ mutually_exclusive_features::none_or_one_of!(
     feature = "opentelemetry_0_28",
     feature = "opentelemetry_0_29",
     feature = "opentelemetry_0_30",
+    feature = "opentelemetry_0_31",
 ))]
 mod otel;

--- a/src/otel.rs
+++ b/src/otel.rs
@@ -36,6 +36,8 @@ use opentelemetry_0_28_pkg as opentelemetry;
 use opentelemetry_0_29_pkg as opentelemetry;
 #[cfg(feature = "opentelemetry_0_30")]
 use opentelemetry_0_30_pkg as opentelemetry;
+#[cfg(feature = "opentelemetry_0_31")]
+use opentelemetry_0_31_pkg as opentelemetry;
 
 #[cfg(feature = "opentelemetry_0_13")]
 use tracing_opentelemetry_0_12_pkg as tracing_opentelemetry;
@@ -73,6 +75,8 @@ use tracing_opentelemetry_0_29_pkg as tracing_opentelemetry;
 use tracing_opentelemetry_0_30_pkg as tracing_opentelemetry;
 #[cfg(feature = "opentelemetry_0_30")]
 use tracing_opentelemetry_0_31_pkg as tracing_opentelemetry;
+#[cfg(feature = "opentelemetry_0_31")]
+use tracing_opentelemetry_0_32_pkg as tracing_opentelemetry;
 
 use opentelemetry::propagation::Extractor;
 
@@ -103,7 +107,7 @@ pub(crate) fn set_otel_parent(req: &ServiceRequest, span: &tracing::Span) {
     let parent_context = opentelemetry::global::get_text_map_propagator(|propagator| {
         propagator.extract(&RequestHeaderCarrier::new(req.headers()))
     });
-    span.set_parent(parent_context);
+    let _ = span.set_parent(parent_context);
     // If we have a remote parent span, this will be the parent's trace identifier.
     // If not, it will be the newly generated trace identifier with this request as root span.
     #[cfg(not(any(
@@ -121,6 +125,7 @@ pub(crate) fn set_otel_parent(req: &ServiceRequest, span: &tracing::Span) {
         feature = "opentelemetry_0_28",
         feature = "opentelemetry_0_29",
         feature = "opentelemetry_0_30",
+        feature = "opentelemetry_0_31",
     )))]
     let trace_id = span.context().span().span_context().trace_id().to_hex();
 
@@ -139,6 +144,7 @@ pub(crate) fn set_otel_parent(req: &ServiceRequest, span: &tracing::Span) {
         feature = "opentelemetry_0_28",
         feature = "opentelemetry_0_29",
         feature = "opentelemetry_0_30",
+        feature = "opentelemetry_0_31",
     ))]
     let trace_id = {
         let id = span.context().span().span_context().trace_id();

--- a/src/root_span_macro.rs
+++ b/src/root_span_macro.rs
@@ -174,6 +174,7 @@ pub mod private {
             feature = "opentelemetry_0_28",
             feature = "opentelemetry_0_29",
             feature = "opentelemetry_0_30",
+            feature = "opentelemetry_0_31",
         ))]
         crate::otel::set_otel_parent(req, span);
     }


### PR DESCRIPTION
Updates to 0.31
- set_parent now returns a result, it only fails if the span is disabled or the span has "already started". I think neither of these is the case for tracing-actix-web's use
- examples are updated
- readme is updated
- version is bumped